### PR TITLE
Several enhancements and proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,7 +289,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -371,7 +421,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -406,7 +456,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -689,7 +739,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -836,6 +886,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +959,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1153,7 +1249,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1173,6 +1269,12 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
+
+[[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document-features"
@@ -1416,7 +1518,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1437,7 +1539,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1485,7 +1587,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1578,7 +1680,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1676,7 +1778,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1773,7 +1875,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1983,7 +2085,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2168,7 +2270,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2434,7 +2536,20 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2446,6 +2561,12 @@ dependencies = [
  "core-foundation-sys",
  "mach2",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -2509,7 +2630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2549,6 +2670,7 @@ dependencies = [
 name = "keypeek"
 version = "0.5.0"
 dependencies = [
+ "clap",
  "dirs",
  "eframe",
  "egui-file-dialog",
@@ -2557,6 +2679,7 @@ dependencies = [
  "gtk",
  "hidapi",
  "image",
+ "interprocess",
  "lzma-rs",
  "qmk-via-api",
  "rust-ini",
@@ -3069,7 +3192,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3121,7 +3244,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3464,6 +3587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3663,7 +3792,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "unicase",
 ]
 
@@ -3677,7 +3806,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3722,7 +3851,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3840,7 +3969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3898,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -3921,7 +4050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3949,7 +4078,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.110",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -3963,7 +4092,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4097,9 +4226,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -4257,6 +4386,12 @@ dependencies = [
  "bytemuck",
  "font-types",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -4536,7 +4671,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4560,7 +4695,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4780,6 +4915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4804,7 +4945,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4816,7 +4957,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4848,9 +4989,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4877,7 +5018,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4959,7 +5100,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4970,7 +5111,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5055,7 +5196,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5164,7 +5305,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5344,6 +5485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5471,7 +5618,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5848,6 +5995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5953,7 +6106,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5975,7 +6128,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6495,7 +6648,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "synstructure 0.13.2",
 ]
 
@@ -6551,7 +6704,7 @@ checksum = "dc6821851fa840b708b4cbbaf6241868cabc85a2dc22f426361b0292bfc0b836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "zbus-lockstep",
  "zbus_xml",
  "zvariant",
@@ -6566,7 +6719,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6614,7 +6767,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6634,7 +6787,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "synstructure 0.13.2",
 ]
 
@@ -6674,7 +6827,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6750,7 +6903,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "zvariant_utils",
 ]
 
@@ -6763,6 +6916,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.110",
+ "syn 2.0.117",
  "winnow 0.7.13",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qmk-via-api = { version = "0.7.0" }
 hidapi = "2.6.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
-egui-phosphor = "0.12.0"
+egui-phosphor = { version = "0.12.0", features = ["fill"] }
 egui-file-dialog = "0.13.0"
 image = "0.25.10"
 lzma-rs = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ image = "0.25.10"
 lzma-rs = "0.3"
 serialport = "4.9.0"
 zmk-studio-api = { version = "0.3.1", features = ["serial", "ble"] }
+clap = { version = "4.6.1", features = ["derive"] }
+interprocess = "2.4.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,43 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    /// Toggle overlay visibility
+    #[arg(short, long)]
+    pub toggle: bool,
+
+    /// Show settings window
+    #[arg(short, long)]
+    pub settings: bool,
+
+    /// Connect to a VIA device using the provided JSON path
+    #[arg(long)]
+    pub via: Option<String>,
+
+    /// Connect to a Vial device using VID:PID (e.g. 1234:5678)
+    #[arg(long)]
+    pub vial: Option<String>,
+
+    /// Connect to a ZMK device using VID:PID (e.g. 1234:5678)
+    #[arg(long)]
+    pub zmk: Option<String>,
+
+    /// ZMK serial port name
+    #[arg(long)]
+    pub serial: Option<String>,
+
+    /// ZMK BLE device ID
+    #[arg(long)]
+    pub ble: Option<String>,
+}
+
+pub fn parse_vid_pid(s: &str) -> Result<(u16, u16), String> {
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() != 2 {
+        return Err("Format must be VID:PID (hex)".to_string());
+    }
+    let vid = u16::from_str_radix(parts[0], 16).map_err(|e| format!("Invalid VID: {e}"))?;
+    let pid = u16::from_str_radix(parts[1], 16).map_err(|e| format!("Invalid PID: {e}"))?;
+    Ok((vid, pid))
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,9 @@
 use crate::keyboard::Keyboard;
 use crate::protocols::{connect_protocol, ConnectionSpec, KeyboardDefinition, KeyboardProtocol};
 use crate::ui_wake::UiWake;
+use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::{self, TryRecvError};
+use std::sync::Arc;
 
 const ZMK_LOCKED_ERROR: &str = "Device is locked. Please press the ZMK Studio unlock key combination on your keyboard, then click Connect again.";
 
@@ -55,10 +57,14 @@ pub struct ConnectionTask {
 }
 
 impl ConnectionTask {
-    pub fn start(request: ConnectionRequest, ui_wake: UiWake) -> Self {
+    pub fn start(
+        request: ConnectionRequest,
+        ui_wake: UiWake,
+        manual_visible: Arc<AtomicBool>,
+    ) -> Self {
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
-            let result = build_connected_state(request, ui_wake.clone());
+            let result = build_connected_state(request, ui_wake.clone(), manual_visible);
             let _ = tx.send(result);
             ui_wake.request_repaint();
         });
@@ -79,6 +85,7 @@ impl ConnectionTask {
 pub fn build_connected_state(
     request: ConnectionRequest,
     ui_wake: UiWake,
+    manual_visible: Arc<AtomicBool>,
 ) -> Result<ConnectedState, String> {
     let protocol = request.connect_protocol()?;
 
@@ -91,6 +98,7 @@ pub fn build_connected_state(
         selected_layout_name.clone(),
         request.timeout,
         ui_wake,
+        manual_visible,
     )
     .map_err(|e| format!("Failed to create keyboard: {e}"))?;
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -43,6 +43,7 @@ fn format_connect_error(spec: &ConnectionSpec, error_text: &str) -> String {
 }
 
 pub struct ConnectedState {
+    pub spec: ConnectionSpec,
     pub definition: KeyboardDefinition,
     pub layout_names: Vec<String>,
     pub selected_layout_name: String,
@@ -94,6 +95,7 @@ pub fn build_connected_state(
     .map_err(|e| format!("Failed to create keyboard: {e}"))?;
 
     Ok(ConnectedState {
+        spec: request.spec,
         definition,
         layout_names,
         selected_layout_name,

--- a/src/key_matrix.rs
+++ b/src/key_matrix.rs
@@ -1,8 +1,10 @@
 use crate::layout_key::LayoutKey;
+use std::time::{Duration, Instant};
 
 pub struct KeyMatrix {
     pub keys: Vec<Vec<Vec<Option<LayoutKey>>>>,
     pub pressed: Vec<Vec<bool>>,
+    pub last_pressed_at: Vec<Vec<Option<Instant>>>,
 }
 
 impl KeyMatrix {
@@ -14,6 +16,7 @@ impl KeyMatrix {
         KeyMatrix {
             keys,
             pressed: vec![vec![false; cols]; rows],
+            last_pressed_at: vec![vec![None; cols]; rows],
         }
     }
 
@@ -39,18 +42,63 @@ impl KeyMatrix {
     }
 
     pub fn is_pressed(&self, row: usize, col: usize) -> bool {
-        self.pressed
+        let physically_pressed = self.pressed
             .get(row)
             .and_then(|r| r.get(col))
             .copied()
-            .unwrap_or(false)
+            .unwrap_or(false);
+
+        if physically_pressed {
+            return true;
+        }
+
+        // Check for minimum highlight duration (50ms) to ensure fast taps are visible
+        if let Some(Some(last_press)) = self.last_pressed_at.get(row).and_then(|r| r.get(col)) {
+            if last_press.elapsed() < Duration::from_millis(50) {
+                return true;
+            }
+        }
+
+        false
     }
 
     pub fn set_pressed(&mut self, row: usize, col: usize, value: bool) {
         if let Some(r) = self.pressed.get_mut(row) {
             if col < r.len() {
                 r[col] = value;
+                if value {
+                    if let Some(times) = self.last_pressed_at.get_mut(row) {
+                        if col < times.len() {
+                            times[col] = Some(Instant::now());
+                        }
+                    }
+                }
             }
         }
+    }
+
+    pub fn get_min_highlight_timeout(&self) -> Option<Duration> {
+        let mut min_timeout: Option<Duration> = None;
+        let now = Instant::now();
+        let duration_50ms = Duration::from_millis(50);
+
+        for (r, row_pressed) in self.pressed.iter().enumerate() {
+            for (c, &physically_pressed) in row_pressed.iter().enumerate() {
+                if !physically_pressed {
+                    if let Some(Some(last_press)) =
+                        self.last_pressed_at.get(r).and_then(|row| row.get(c))
+                    {
+                        if let Some(elapsed) = now.checked_duration_since(*last_press) {
+                            if elapsed < duration_50ms {
+                                let remaining = duration_50ms - elapsed;
+                                min_timeout =
+                                    Some(min_timeout.map_or(remaining, |min| min.min(remaining)));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        min_timeout
     }
 }

--- a/src/key_matrix.rs
+++ b/src/key_matrix.rs
@@ -1,6 +1,8 @@
 use crate::layout_key::LayoutKey;
 use std::time::{Duration, Instant};
 
+const MIN_HIGHLIGHT_DURATION: Duration = Duration::from_millis(50);
+
 pub struct KeyMatrix {
     pub keys: Vec<Vec<Vec<Option<LayoutKey>>>>,
     pub pressed: Vec<Vec<bool>>,
@@ -41,6 +43,10 @@ impl KeyMatrix {
             .unwrap_or(true)
     }
 
+    /// Returns whether the key should currently be shown as pressed.
+    ///
+    /// This includes keys that are physically pressed as well as recently released keys
+    /// that still fall within the minimum highlight duration window.
     pub fn is_pressed(&self, row: usize, col: usize) -> bool {
         let physically_pressed = self.pressed
             .get(row)
@@ -52,9 +58,9 @@ impl KeyMatrix {
             return true;
         }
 
-        // Check for minimum highlight duration (50ms) to ensure fast taps are visible
+        // Check for minimum highlight duration to ensure fast taps are visible
         if let Some(Some(last_press)) = self.last_pressed_at.get(row).and_then(|r| r.get(col)) {
-            if last_press.elapsed() < Duration::from_millis(50) {
+            if last_press.elapsed() < MIN_HIGHLIGHT_DURATION {
                 return true;
             }
         }
@@ -80,7 +86,7 @@ impl KeyMatrix {
     pub fn get_min_highlight_timeout(&self) -> Option<Duration> {
         let mut min_timeout: Option<Duration> = None;
         let now = Instant::now();
-        let duration_50ms = Duration::from_millis(50);
+        let duration_50ms = MIN_HIGHLIGHT_DURATION;
 
         for (r, row_pressed) in self.pressed.iter().enumerate() {
             for (c, &physically_pressed) in row_pressed.iter().enumerate() {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -14,7 +15,7 @@ pub struct Keyboard {
     layer_state: Arc<Mutex<u32>>,
     default_layer_state: Arc<Mutex<u32>>,
     timeout_ms: Arc<Mutex<i64>>,
-    pub show_on_layer_change: Arc<Mutex<bool>>,
+    pub show_on_layer_change: Arc<AtomicBool>,
     disconnected: Arc<std::sync::atomic::AtomicBool>,
 }
 
@@ -43,7 +44,7 @@ impl Keyboard {
         let default_layer_state = Arc::new(Mutex::new(0));
         let time_to_hide_overlay = Arc::new(Mutex::new(Some(Instant::now())));
         let timeout_ms = Arc::new(Mutex::new(timeout));
-        let show_on_layer_change = Arc::new(Mutex::new(true));
+        let show_on_layer_change = Arc::new(AtomicBool::new(true));
         let matrix = Arc::new(Mutex::new(matrix));
         let disconnected = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
@@ -73,12 +74,18 @@ impl Keyboard {
                 match protocol.hid_read() {
                     Ok(response) => {
                         error_count = 0;
+                        disconnected_clone.store(false, std::sync::atomic::Ordering::Relaxed);
                         if response.is_empty() {
                             continue;
                         }
                         let mut needs_repaint = false;
                         if response[0] == 0xff {
                             let size = response[1] as usize;
+
+                            if size > 4 || response.len() < 2 + 2 * size {
+                                eprintln!("Invalid size {} or response length {} for layer state update", size, response.len());
+                                continue;
+                            }
 
                             let mut default_bytes = [0u8; 4];
                             default_bytes[..size].copy_from_slice(&response[2..2 + size]);
@@ -88,7 +95,7 @@ impl Keyboard {
                             layer_bytes[..size].copy_from_slice(&response[2 + size..2 + 2 * size]);
                             let layer_state = u32::from_le_bytes(layer_bytes);
 
-                            if *show_on_layer_change_clone.lock().unwrap() {
+                            if show_on_layer_change_clone.load(Ordering::SeqCst) {
                                 if layer_state > 1 {
                                     *time_to_hide_clone.lock().unwrap() = None;
                                 } else {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -14,6 +14,7 @@ pub struct Keyboard {
     layer_state: Arc<Mutex<u32>>,
     default_layer_state: Arc<Mutex<u32>>,
     timeout_ms: Arc<Mutex<i64>>,
+    pub show_on_layer_change: Arc<Mutex<bool>>,
 }
 
 impl Keyboard {
@@ -40,6 +41,7 @@ impl Keyboard {
         let default_layer_state = Arc::new(Mutex::new(0));
         let time_to_hide_overlay = Arc::new(Mutex::new(Some(Instant::now())));
         let timeout_ms = Arc::new(Mutex::new(timeout));
+        let show_on_layer_change = Arc::new(Mutex::new(true));
         let matrix = Arc::new(Mutex::new(matrix));
 
         let keyboard = Keyboard {
@@ -49,12 +51,14 @@ impl Keyboard {
             layer_state: Arc::clone(&layer_state),
             default_layer_state: Arc::clone(&default_layer_state),
             timeout_ms: Arc::clone(&timeout_ms),
+            show_on_layer_change: Arc::clone(&show_on_layer_change),
         };
 
         let layer_state_clone = Arc::clone(&keyboard.layer_state);
         let default_layer_state_clone = Arc::clone(&keyboard.default_layer_state);
         let time_to_hide_clone = Arc::clone(&keyboard.time_to_hide_overlay);
         let timeout_clone = Arc::clone(&keyboard.timeout_ms);
+        let show_on_layer_change_clone = Arc::clone(&show_on_layer_change);
         let matrix_clone = Arc::clone(&matrix);
 
         thread::spawn(move || loop {
@@ -71,16 +75,18 @@ impl Keyboard {
                     layer_bytes[..size].copy_from_slice(&response[2 + size..2 + 2 * size]);
                     let layer_state = u32::from_le_bytes(layer_bytes);
 
-                    if layer_state > 1 {
-                        *time_to_hide_clone.lock().unwrap() = None;
-                    } else {
-                        let timeout = *timeout_clone.lock().unwrap();
-                        if timeout < 0 {
+                    if *show_on_layer_change_clone.lock().unwrap() {
+                        if layer_state > 1 {
                             *time_to_hide_clone.lock().unwrap() = None;
                         } else {
-                            let time_to_hide =
-                                Instant::now() + Duration::from_millis(timeout as u64);
-                            *time_to_hide_clone.lock().unwrap() = Some(time_to_hide);
+                            let timeout = *timeout_clone.lock().unwrap();
+                            if timeout < 0 {
+                                *time_to_hide_clone.lock().unwrap() = None;
+                            } else {
+                                let time_to_hide =
+                                    Instant::now() + Duration::from_millis(timeout as u64);
+                                *time_to_hide_clone.lock().unwrap() = Some(time_to_hide);
+                            }
                         }
                     }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -15,6 +15,7 @@ pub struct Keyboard {
     default_layer_state: Arc<Mutex<u32>>,
     timeout_ms: Arc<Mutex<i64>>,
     pub show_on_layer_change: Arc<Mutex<bool>>,
+    disconnected: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Keyboard {
@@ -44,6 +45,7 @@ impl Keyboard {
         let timeout_ms = Arc::new(Mutex::new(timeout));
         let show_on_layer_change = Arc::new(Mutex::new(true));
         let matrix = Arc::new(Mutex::new(matrix));
+        let disconnected = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         let keyboard = Keyboard {
             layout,
@@ -53,6 +55,7 @@ impl Keyboard {
             default_layer_state: Arc::clone(&default_layer_state),
             timeout_ms: Arc::clone(&timeout_ms),
             show_on_layer_change: Arc::clone(&show_on_layer_change),
+            disconnected: Arc::clone(&disconnected),
         };
 
         let layer_state_clone = Arc::clone(&keyboard.layer_state);
@@ -62,76 +65,97 @@ impl Keyboard {
         let show_on_layer_change_clone = Arc::clone(&show_on_layer_change);
         let matrix_clone = Arc::clone(&matrix);
         let manual_visible_clone = Arc::clone(&manual_visible);
+        let disconnected_clone = Arc::clone(&disconnected);
 
-        thread::spawn(move || loop {
-            match protocol.hid_read() {
-                Ok(response) => {
-                    if response.is_empty() {
-                        continue;
-                    }
-                    let mut needs_repaint = false;
-                    if response[0] == 0xff {
-                        let size = response[1] as usize;
+        thread::spawn(move || {
+            let mut error_count = 0;
+            loop {
+                match protocol.hid_read() {
+                    Ok(response) => {
+                        error_count = 0;
+                        if response.is_empty() {
+                            continue;
+                        }
+                        let mut needs_repaint = false;
+                        if response[0] == 0xff {
+                            let size = response[1] as usize;
 
-                        let mut default_bytes = [0u8; 4];
-                        default_bytes[..size].copy_from_slice(&response[2..2 + size]);
-                        let default_layer_state = u32::from_le_bytes(default_bytes);
+                            let mut default_bytes = [0u8; 4];
+                            default_bytes[..size].copy_from_slice(&response[2..2 + size]);
+                            let default_layer_state = u32::from_le_bytes(default_bytes);
 
-                        let mut layer_bytes = [0u8; 4];
-                        layer_bytes[..size].copy_from_slice(&response[2 + size..2 + 2 * size]);
-                        let layer_state = u32::from_le_bytes(layer_bytes);
+                            let mut layer_bytes = [0u8; 4];
+                            layer_bytes[..size].copy_from_slice(&response[2 + size..2 + 2 * size]);
+                            let layer_state = u32::from_le_bytes(layer_bytes);
 
-                        if *show_on_layer_change_clone.lock().unwrap() {
-                            if layer_state > 1 {
-                                *time_to_hide_clone.lock().unwrap() = None;
-                            } else {
-                                let timeout = *timeout_clone.lock().unwrap();
-                                if timeout < 0 {
+                            if *show_on_layer_change_clone.lock().unwrap() {
+                                if layer_state > 1 {
                                     *time_to_hide_clone.lock().unwrap() = None;
                                 } else {
-                                    let time_to_hide =
-                                        Instant::now() + Duration::from_millis(timeout as u64);
-                                    *time_to_hide_clone.lock().unwrap() = Some(time_to_hide);
+                                    let timeout = *timeout_clone.lock().unwrap();
+                                    if timeout < 0 {
+                                        *time_to_hide_clone.lock().unwrap() = None;
+                                    } else {
+                                        let time_to_hide =
+                                            Instant::now() + Duration::from_millis(timeout as u64);
+                                        *time_to_hide_clone.lock().unwrap() = Some(time_to_hide);
+                                    }
                                 }
                             }
-                        }
 
-                        *layer_state_clone.lock().unwrap() = layer_state;
-                        *default_layer_state_clone.lock().unwrap() = default_layer_state;
-                        needs_repaint = true;
-                    } else if response[0] == 0xF1 {
-                        let row = response[1] as usize;
-                        let col = response[2] as usize;
-                        let pressed = response[3] != 0;
+                            *layer_state_clone.lock().unwrap() = layer_state;
+                            *default_layer_state_clone.lock().unwrap() = default_layer_state;
+                            needs_repaint = true;
+                        } else if response[0] == 0xF1 {
+                            let row = response[1] as usize;
+                            let col = response[2] as usize;
+                            let pressed = response[3] != 0;
 
-                        if let Ok(mut mat) = matrix_clone.lock() {
-                            if row < mat.pressed.len() && col < mat.pressed[0].len() {
-                                mat.set_pressed(row, col, pressed);
+                            if let Ok(mut mat) = matrix_clone.lock() {
+                                if row < mat.pressed.len() && col < mat.pressed[0].len() {
+                                    mat.set_pressed(row, col, pressed);
+                                }
                             }
+
+                            let manual =
+                                manual_visible_clone.load(std::sync::atomic::Ordering::Relaxed);
+                            let timeout_active = time_to_hide_clone
+                                .lock()
+                                .unwrap()
+                                .as_ref()
+                                .is_none_or(|time_to_hide| Instant::now() < *time_to_hide);
+
+                            needs_repaint = manual || timeout_active;
                         }
 
-                        let manual = manual_visible_clone.load(std::sync::atomic::Ordering::Relaxed);
-                        let timeout_active = time_to_hide_clone
-                            .lock()
-                            .unwrap()
-                            .as_ref()
-                            .is_none_or(|time_to_hide| Instant::now() < *time_to_hide);
-
-                        needs_repaint = manual || timeout_active;
+                        if needs_repaint {
+                            ui_wake.request_repaint();
+                        }
                     }
+                    Err(e) => {
+                        error_count += 1;
+                        if error_count == 1 {
+                            eprintln!("HID Read Error: {}", e);
+                        }
 
-                    if needs_repaint {
-                        ui_wake.request_repaint();
+                        if error_count > 10 {
+                            disconnected_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+                            ui_wake.request_repaint();
+                        }
+
+                        let delay = (100 * (1 << (error_count.min(6) - 1))).min(5000);
+                        thread::sleep(Duration::from_millis(delay));
                     }
-                }
-                Err(e) => {
-                    eprintln!("HID Read Error: {}", e);
-                    thread::sleep(Duration::from_millis(100));
                 }
             }
         });
 
         Ok(keyboard)
+    }
+
+    pub fn is_disconnected(&self) -> bool {
+        self.disconnected
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn get_effective_key_layer(&self, row: usize, col: usize) -> (u8, bool) {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -23,6 +23,7 @@ impl Keyboard {
         layout_name: String,
         timeout: i64,
         ui_wake: UiWake,
+        manual_visible: Arc<std::sync::atomic::AtomicBool>,
     ) -> Result<Self, String> {
         let definition = protocol.get_layout_definition();
 
@@ -60,55 +61,72 @@ impl Keyboard {
         let timeout_clone = Arc::clone(&keyboard.timeout_ms);
         let show_on_layer_change_clone = Arc::clone(&show_on_layer_change);
         let matrix_clone = Arc::clone(&matrix);
+        let manual_visible_clone = Arc::clone(&manual_visible);
 
         thread::spawn(move || loop {
-            if let Ok(response) = protocol.hid_read() {
-                let mut needs_repaint = false;
-                if response[0] == 0xff {
-                    let size = response[1] as usize;
+            match protocol.hid_read() {
+                Ok(response) => {
+                    if response.is_empty() {
+                        continue;
+                    }
+                    let mut needs_repaint = false;
+                    if response[0] == 0xff {
+                        let size = response[1] as usize;
 
-                    let mut default_bytes = [0u8; 4];
-                    default_bytes[..size].copy_from_slice(&response[2..2 + size]);
-                    let default_layer_state = u32::from_le_bytes(default_bytes);
+                        let mut default_bytes = [0u8; 4];
+                        default_bytes[..size].copy_from_slice(&response[2..2 + size]);
+                        let default_layer_state = u32::from_le_bytes(default_bytes);
 
-                    let mut layer_bytes = [0u8; 4];
-                    layer_bytes[..size].copy_from_slice(&response[2 + size..2 + 2 * size]);
-                    let layer_state = u32::from_le_bytes(layer_bytes);
+                        let mut layer_bytes = [0u8; 4];
+                        layer_bytes[..size].copy_from_slice(&response[2 + size..2 + 2 * size]);
+                        let layer_state = u32::from_le_bytes(layer_bytes);
 
-                    if *show_on_layer_change_clone.lock().unwrap() {
-                        if layer_state > 1 {
-                            *time_to_hide_clone.lock().unwrap() = None;
-                        } else {
-                            let timeout = *timeout_clone.lock().unwrap();
-                            if timeout < 0 {
+                        if *show_on_layer_change_clone.lock().unwrap() {
+                            if layer_state > 1 {
                                 *time_to_hide_clone.lock().unwrap() = None;
                             } else {
-                                let time_to_hide =
-                                    Instant::now() + Duration::from_millis(timeout as u64);
-                                *time_to_hide_clone.lock().unwrap() = Some(time_to_hide);
+                                let timeout = *timeout_clone.lock().unwrap();
+                                if timeout < 0 {
+                                    *time_to_hide_clone.lock().unwrap() = None;
+                                } else {
+                                    let time_to_hide =
+                                        Instant::now() + Duration::from_millis(timeout as u64);
+                                    *time_to_hide_clone.lock().unwrap() = Some(time_to_hide);
+                                }
                             }
                         }
+
+                        *layer_state_clone.lock().unwrap() = layer_state;
+                        *default_layer_state_clone.lock().unwrap() = default_layer_state;
+                        needs_repaint = true;
+                    } else if response[0] == 0xF1 {
+                        let row = response[1] as usize;
+                        let col = response[2] as usize;
+                        let pressed = response[3] != 0;
+
+                        if let Ok(mut mat) = matrix_clone.lock() {
+                            if row < mat.pressed.len() && col < mat.pressed[0].len() {
+                                mat.set_pressed(row, col, pressed);
+                            }
+                        }
+
+                        let manual = manual_visible_clone.load(std::sync::atomic::Ordering::Relaxed);
+                        let timeout_active = time_to_hide_clone
+                            .lock()
+                            .unwrap()
+                            .as_ref()
+                            .is_none_or(|time_to_hide| Instant::now() < *time_to_hide);
+
+                        needs_repaint = manual || timeout_active;
                     }
 
-                    *layer_state_clone.lock().unwrap() = layer_state;
-                    *default_layer_state_clone.lock().unwrap() = default_layer_state;
-                    needs_repaint = true;
-                } else if response[0] == 0xF1 {
-                    let row = response[1] as usize;
-                    let col = response[2] as usize;
-                    let pressed = response[3];
-                    if let Ok(mut mat) = matrix_clone.lock() {
-                        mat.set_pressed(row, col, pressed != 0);
+                    if needs_repaint {
+                        ui_wake.request_repaint();
                     }
-                    needs_repaint = time_to_hide_clone
-                        .lock()
-                        .unwrap()
-                        .as_ref()
-                        .is_none_or(|time_to_hide| Instant::now() < *time_to_hide);
                 }
-
-                if needs_repaint {
-                    ui_wake.request_repaint();
+                Err(e) => {
+                    eprintln!("HID Read Error: {}", e);
+                    thread::sleep(Duration::from_millis(100));
                 }
             }
         });
@@ -151,6 +169,10 @@ impl Keyboard {
 
     pub fn is_key_pressed(&self, row: usize, col: usize) -> bool {
         self.matrix.lock().unwrap().is_pressed(row, col)
+    }
+
+    pub fn get_highlight_timeout(&self) -> Option<Duration> {
+        self.matrix.lock().unwrap().get_min_highlight_timeout()
     }
 
     pub fn set_timeout(&self, timeout: i64) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,7 @@ fn main() -> Result<(), eframe::Error> {
 
             let mut fonts = egui::FontDefinitions::default();
             egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
+            egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Fill);
             cc.egui_ctx.set_fonts(fonts);
 
             let ui_wake = UiWake::from_ctx(&cc.egui_ctx);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+mod cli;
 mod connection;
 mod device_discovery;
 mod key_matrix;
@@ -12,14 +13,103 @@ mod tray;
 mod ui_wake;
 mod zmk_keycode_labels;
 
+use clap::Parser;
+use cli::{Cli, parse_vid_pid};
 use device_discovery::discover_devices;
 use eframe::egui;
+use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions, Stream};
 use overlay_window::OverlayApp;
+use protocols::{ConnectionSpec, ZmkTransportConfig};
 use settings::Settings;
+use std::io::{Read, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use ui_wake::UiWake;
 
 fn main() -> Result<(), eframe::Error> {
-    let settings = Settings::load().unwrap_or_default();
+    let cli = Cli::parse();
+
+    let socket_name = "keypeek.sock"
+        .to_ns_name::<GenericNamespaced>()
+        .expect("Failed to create socket name");
+
+    if let Ok(mut stream) = Stream::connect(socket_name.clone()) {
+        if cli.settings {
+            let _ = stream.write_all(b"settin");
+            let _ = stream.flush();
+        } else if cli.toggle {
+            let _ = stream.write_all(b"toggle");
+            let _ = stream.flush();
+        }
+        return Ok(());
+    }
+
+    let listener = ListenerOptions::new()
+        .name(socket_name)
+        .create_sync()
+        .expect("Failed to bind local socket");
+
+    let manual_visible = Arc::new(AtomicBool::new(cli.toggle));
+    let force_settings = Arc::new(AtomicBool::new(cli.settings));
+    let ui_wake_cell = Arc::new(std::sync::Mutex::new(None::<UiWake>));
+
+    {
+        let manual_visible = Arc::clone(&manual_visible);
+        let force_settings = Arc::clone(&force_settings);
+        let ui_wake_cell = Arc::clone(&ui_wake_cell);
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                if let Ok(mut stream) = stream {
+                    let mut buf = [0u8; 6];
+                    if stream.read_exact(&mut buf).is_ok() {
+                        let cmd = std::str::from_utf8(&buf).unwrap_or("");
+                        if cmd == "toggle" {
+                            let current = manual_visible.load(Ordering::Relaxed);
+                            manual_visible.store(!current, Ordering::Relaxed);
+                        } else if cmd == "settin" {
+                            force_settings.store(true, Ordering::Relaxed);
+                        }
+
+                        if let Some(wake) = ui_wake_cell.lock().unwrap().as_ref() {
+                            wake.request_repaint();
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    let mut settings = Settings::load().unwrap_or_default();
+
+    // Override settings with CLI flags
+    if let Some(json_path) = cli.via {
+        settings.last_connection = Some(ConnectionSpec::Via { json_path });
+    } else if let Some(vial_str) = cli.vial {
+        if let Ok((vid, pid)) = parse_vid_pid(&vial_str) {
+            settings.last_connection = Some(ConnectionSpec::Vial { vid, pid });
+        }
+    } else if let Some(zmk_str) = cli.zmk {
+        if let Ok((vid, pid)) = parse_vid_pid(&zmk_str) {
+            let transport = if let Some(port) = cli.serial {
+                ZmkTransportConfig::Serial(port)
+            } else if let Some(id) = cli.ble {
+                ZmkTransportConfig::Ble(id)
+            } else {
+                let serial_ports = protocols::zmk_rpc::scan_serial_ports();
+                if let Some(port) = serial_ports.into_iter().find(|p| p.vid == vid && p.pid == pid) {
+                    ZmkTransportConfig::Serial(port.port_name)
+                } else {
+                    ZmkTransportConfig::Serial("AUTO".to_string())
+                }
+            };
+            settings.last_connection = Some(ConnectionSpec::Zmk {
+                vid,
+                pid,
+                transport,
+            });
+        }
+    }
+
     let available_devices = discover_devices();
 
     let options = eframe::NativeOptions {
@@ -51,11 +141,16 @@ fn main() -> Result<(), eframe::Error> {
             egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
             cc.egui_ctx.set_fonts(fonts);
 
+            let ui_wake = UiWake::from_ctx(&cc.egui_ctx);
+            *ui_wake_cell.lock().unwrap() = Some(ui_wake.clone());
+
             Ok(Box::new(OverlayApp::new(
                 tray_icon,
-                UiWake::from_ctx(&cc.egui_ctx),
+                ui_wake,
                 settings,
                 available_devices,
+                manual_visible,
+                force_settings,
             )))
         }),
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), eframe::Error> {
 
     if let Ok(mut stream) = Stream::connect(socket_name.clone()) {
         if cli.settings {
-            let _ = stream.write_all(b"settin");
+            let _ = stream.write_all(b"settings");
             let _ = stream.flush();
         } else if cli.toggle {
             let _ = stream.write_all(b"toggle");
@@ -60,13 +60,15 @@ fn main() -> Result<(), eframe::Error> {
         std::thread::spawn(move || {
             for stream in listener.incoming() {
                 if let Ok(mut stream) = stream {
-                    let mut buf = [0u8; 6];
-                    if stream.read_exact(&mut buf).is_ok() {
-                        let cmd = std::str::from_utf8(&buf).unwrap_or("");
-                        if cmd == "toggle" {
+                    // We only expect a small command, but we should read what's there
+                    // local_socket streams usually close or signal end of data when flushed/dropped
+                    let mut temp_buf = [0u8; 32];
+                    if let Ok(n) = stream.read(&mut temp_buf) {
+                        let cmd = std::str::from_utf8(&temp_buf[..n]).unwrap_or("");
+                        if cmd.starts_with("toggle") {
                             let current = manual_visible.load(Ordering::Relaxed);
                             manual_visible.store(!current, Ordering::Relaxed);
-                        } else if cmd == "settin" {
+                        } else if cmd.starts_with("settings") {
                             force_settings.store(true, Ordering::Relaxed);
                         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+ #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 mod cli;
 mod connection;
 mod device_discovery;
@@ -35,11 +35,24 @@ fn main() -> Result<(), eframe::Error> {
 
     if let Ok(mut stream) = Stream::connect(socket_name.clone()) {
         if cli.settings {
-            let _ = stream.write_all(b"settings");
-            let _ = stream.flush();
+            stream
+                .write_all(b"settings")
+                .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
+            stream
+                .flush()
+                .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
         } else if cli.toggle {
-            let _ = stream.write_all(b"toggle");
-            let _ = stream.flush();
+            stream
+                .write_all(b"toggle")
+                .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
+            stream
+                .flush()
+                .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
+        } else {
+            eprintln!(
+                "App is already running but no command was provided; use --settings or --toggle."
+            );
+            std::process::exit(1);
         }
         return Ok(());
     }
@@ -66,8 +79,7 @@ fn main() -> Result<(), eframe::Error> {
                     if let Ok(n) = stream.read(&mut temp_buf) {
                         let cmd = std::str::from_utf8(&temp_buf[..n]).unwrap_or("");
                         if cmd.starts_with("toggle") {
-                            let current = manual_visible.load(Ordering::Relaxed);
-                            manual_visible.store(!current, Ordering::Relaxed);
+                            manual_visible.fetch_xor(true, Ordering::Relaxed);
                         } else if cmd.starts_with("settings") {
                             force_settings.store(true, Ordering::Relaxed);
                         }
@@ -87,29 +99,49 @@ fn main() -> Result<(), eframe::Error> {
     if let Some(json_path) = cli.via {
         settings.last_connection = Some(ConnectionSpec::Via { json_path });
     } else if let Some(vial_str) = cli.vial {
-        if let Ok((vid, pid)) = parse_vid_pid(&vial_str) {
-            settings.last_connection = Some(ConnectionSpec::Vial { vid, pid });
+        match parse_vid_pid(&vial_str) {
+            Ok((vid, pid)) => {
+                settings.last_connection = Some(ConnectionSpec::Vial { vid, pid });
+            }
+            Err(err) => {
+                eprintln!(
+                    "Invalid Vial VID:PID '{}': {}. Expected VID:PID like 1234:5678",
+                    vial_str,
+                    err
+                );
+                std::process::exit(1);
+            }
         }
     } else if let Some(zmk_str) = cli.zmk {
-        if let Ok((vid, pid)) = parse_vid_pid(&zmk_str) {
-            let transport = if let Some(port) = cli.serial {
-                ZmkTransportConfig::Serial(port)
-            } else if let Some(id) = cli.ble {
-                ZmkTransportConfig::Ble(id)
+        let (vid, pid) = match parse_vid_pid(&zmk_str) {
+            Ok((vid, pid)) => (vid, pid),
+            Err(err) => {
+                eprintln!(
+                    "Invalid ZMK VID:PID '{}': {}. Expected VID:PID like 1234:5678",
+                    zmk_str,
+                    err
+                );
+                std::process::exit(1);
+            }
+        };
+
+        let transport = if let Some(port) = cli.serial {
+            ZmkTransportConfig::Serial(port)
+        } else if let Some(id) = cli.ble {
+            ZmkTransportConfig::Ble(id)
+        } else {
+            let serial_ports = protocols::zmk_rpc::scan_serial_ports();
+            if let Some(port) = serial_ports.into_iter().find(|p| p.vid == vid && p.pid == pid) {
+                ZmkTransportConfig::Serial(port.port_name)
             } else {
-                let serial_ports = protocols::zmk_rpc::scan_serial_ports();
-                if let Some(port) = serial_ports.into_iter().find(|p| p.vid == vid && p.pid == pid) {
-                    ZmkTransportConfig::Serial(port.port_name)
-                } else {
-                    ZmkTransportConfig::Serial("AUTO".to_string())
-                }
-            };
-            settings.last_connection = Some(ConnectionSpec::Zmk {
-                vid,
-                pid,
-                transport,
-            });
-        }
+                ZmkTransportConfig::Serial("AUTO".to_string())
+            }
+        };
+        settings.last_connection = Some(ConnectionSpec::Zmk {
+            vid,
+            pid,
+            transport,
+        });
     }
 
     let available_devices = discover_devices();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
- #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 mod cli;
 mod connection;
 mod device_discovery;
@@ -14,53 +14,102 @@ mod ui_wake;
 mod zmk_keycode_labels;
 
 use clap::Parser;
-use cli::{Cli, parse_vid_pid};
+use cli::{parse_vid_pid, Cli};
 use device_discovery::discover_devices;
 use eframe::egui;
 use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions, Stream};
 use overlay_window::OverlayApp;
 use protocols::{ConnectionSpec, ZmkTransportConfig};
 use settings::Settings;
+use std::io::ErrorKind;
 use std::io::{Read, Write};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use ui_wake::UiWake;
+
+const SOCKET_BASENAME: &str = "keypeek.sock";
+
+fn send_command_to_running_instance(cli: &Cli, mut stream: Stream) -> Result<(), eframe::Error> {
+    if cli.settings {
+        stream
+            .write_all(b"settings")
+            .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
+        stream
+            .flush()
+            .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
+    } else if cli.toggle {
+        stream
+            .write_all(b"toggle")
+            .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
+        stream
+            .flush()
+            .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
+    } else {
+        eprintln!(
+            "App is already running but no command was provided; use --settings or --toggle."
+        );
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
 
 fn main() -> Result<(), eframe::Error> {
     let cli = Cli::parse();
 
-    let socket_name = "keypeek.sock"
+    let socket_name = SOCKET_BASENAME
         .to_ns_name::<GenericNamespaced>()
         .expect("Failed to create socket name");
 
-    if let Ok(mut stream) = Stream::connect(socket_name.clone()) {
-        if cli.settings {
-            stream
-                .write_all(b"settings")
-                .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
-            stream
-                .flush()
-                .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
-        } else if cli.toggle {
-            stream
-                .write_all(b"toggle")
-                .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
-            stream
-                .flush()
-                .map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
-        } else {
-            eprintln!(
-                "App is already running but no command was provided; use --settings or --toggle."
-            );
-            std::process::exit(1);
-        }
+    if let Ok(stream) = Stream::connect(socket_name.clone()) {
+        send_command_to_running_instance(&cli, stream)?;
         return Ok(());
     }
 
-    let listener = ListenerOptions::new()
-        .name(socket_name)
+    let listener = match ListenerOptions::new()
+        .name(socket_name.clone())
         .create_sync()
-        .expect("Failed to bind local socket");
+    {
+        Ok(listener) => listener,
+        Err(err) if err.kind() == ErrorKind::AddrInUse => {
+            if let Ok(stream) = Stream::connect(socket_name.clone()) {
+                send_command_to_running_instance(&cli, stream)?;
+                return Ok(());
+            }
+
+            #[cfg(unix)]
+            {
+                let stale_socket_path = std::path::Path::new("/tmp").join(SOCKET_BASENAME);
+                if stale_socket_path.exists() {
+                    std::fs::remove_file(&stale_socket_path).unwrap_or_else(|remove_err| {
+                        panic!(
+                            "Failed to bind local socket and could not remove stale socket '{}': {}",
+                            stale_socket_path.display(),
+                            remove_err
+                        )
+                    });
+
+                    ListenerOptions::new()
+                        .name(socket_name.clone())
+                        .create_sync()
+                        .unwrap_or_else(|retry_err| {
+                            panic!(
+                                "Failed to bind local socket after stale-socket cleanup: {}",
+                                retry_err
+                            )
+                        })
+                } else {
+                    panic!("Failed to bind local socket: {}", err);
+                }
+            }
+
+            #[cfg(not(unix))]
+            {
+                panic!("Failed to bind local socket: {}", err);
+            }
+        }
+        Err(err) => panic!("Failed to bind local socket: {}", err),
+    };
 
     let manual_visible = Arc::new(AtomicBool::new(cli.toggle));
     let force_settings = Arc::new(AtomicBool::new(cli.settings));
@@ -106,8 +155,7 @@ fn main() -> Result<(), eframe::Error> {
             Err(err) => {
                 eprintln!(
                     "Invalid Vial VID:PID '{}': {}. Expected VID:PID like 1234:5678",
-                    vial_str,
-                    err
+                    vial_str, err
                 );
                 std::process::exit(1);
             }
@@ -118,8 +166,7 @@ fn main() -> Result<(), eframe::Error> {
             Err(err) => {
                 eprintln!(
                     "Invalid ZMK VID:PID '{}': {}. Expected VID:PID like 1234:5678",
-                    zmk_str,
-                    err
+                    zmk_str, err
                 );
                 std::process::exit(1);
             }
@@ -131,7 +178,10 @@ fn main() -> Result<(), eframe::Error> {
             ZmkTransportConfig::Ble(id)
         } else {
             let serial_ports = protocols::zmk_rpc::scan_serial_ports();
-            if let Some(port) = serial_ports.into_iter().find(|p| p.vid == vid && p.pid == pid) {
+            if let Some(port) = serial_ports
+                .into_iter()
+                .find(|p| p.vid == vid && p.pid == pid)
+            {
                 ZmkTransportConfig::Serial(port.port_name)
             } else {
                 ZmkTransportConfig::Serial("AUTO".to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,28 @@ use protocols::{ConnectionSpec, ZmkTransportConfig};
 use settings::Settings;
 use std::io::ErrorKind;
 use std::io::{Read, Write};
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use ui_wake::UiWake;
 
 const SOCKET_BASENAME: &str = "keypeek.sock";
+const DETACHED_TOGGLE_ENV: &str = "KEYPEEK_DETACHED_TOGGLE";
+
+fn spawn_detached_self() -> std::io::Result<()> {
+    let current_exe = std::env::current_exe()?;
+
+    let mut command = Command::new(current_exe);
+    command
+        .args(std::env::args_os().skip(1))
+        .env(DETACHED_TOGGLE_ENV, "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    command.spawn()?;
+    Ok(())
+}
 
 fn send_command_to_running_instance(cli: &Cli, mut stream: Stream) -> Result<(), eframe::Error> {
     if cli.settings {
@@ -63,6 +80,11 @@ fn main() -> Result<(), eframe::Error> {
 
     if let Ok(stream) = Stream::connect(socket_name.clone()) {
         send_command_to_running_instance(&cli, stream)?;
+        return Ok(());
+    }
+
+    if cli.toggle && std::env::var_os(DETACHED_TOGGLE_ENV).is_none() {
+        spawn_detached_self().map_err(|e| eframe::Error::AppCreation(Box::new(e)))?;
         return Ok(());
     }
 

--- a/src/overlay_window.rs
+++ b/src/overlay_window.rs
@@ -52,7 +52,7 @@ impl OverlayApp {
             },
             session: SessionState {
                 connection: AppConnectionState::Disconnected,
-                ever_connected: false,
+                has_connected: false,
                 connected_definition: None,
                 layout_names: Vec::new(),
                 active_layout_name: String::new(),

--- a/src/overlay_window.rs
+++ b/src/overlay_window.rs
@@ -95,17 +95,25 @@ impl OverlayApp {
             return;
         };
 
-        let Some(time_to_hide) = keyboard
+        let mut min_delay: Option<std::time::Duration> = None;
+
+        if let Some(time_to_hide) = keyboard
             .time_to_hide_overlay
             .lock()
             .unwrap()
             .as_ref()
             .copied()
-        else {
-            return;
-        };
+        {
+            if let Some(delay) = time_to_hide.checked_duration_since(Instant::now()) {
+                min_delay = Some(delay);
+            }
+        }
 
-        if let Some(delay) = time_to_hide.checked_duration_since(Instant::now()) {
+        if let Some(highlight_delay) = keyboard.get_highlight_timeout() {
+            min_delay = Some(min_delay.map_or(highlight_delay, |min| min.min(highlight_delay)));
+        }
+
+        if let Some(delay) = min_delay {
             ctx.request_repaint_after(delay);
         }
     }

--- a/src/overlay_window.rs
+++ b/src/overlay_window.rs
@@ -146,6 +146,14 @@ impl eframe::App for OverlayApp {
             self.ui.settings_visible = true;
         }
 
+        if let AppConnectionState::Connected { keyboard } = &self.session.connection {
+            if keyboard.is_disconnected() {
+                self.disconnect();
+                self.ui.settings_visible = true;
+                self.ui.settings_warning = Some("Device disconnected".to_string());
+            }
+        }
+
         self.poll_connect_result();
 
         self.apply_live_visual_settings();

--- a/src/overlay_window.rs
+++ b/src/overlay_window.rs
@@ -29,8 +29,10 @@ impl OverlayApp {
         ui_wake: UiWake,
         base_settings: Settings,
         available_devices: Vec<DiscoveredDevice>,
+        manual_visible: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        force_settings: std::sync::Arc<std::sync::atomic::AtomicBool>,
     ) -> Self {
-        Self {
+        let mut app = Self {
             _tray_icon: tray_icon,
             ui_wake,
             ui: UiState {
@@ -38,6 +40,8 @@ impl OverlayApp {
                 settings_error: None,
                 settings_warning: None,
                 mouse_passthrough: None,
+                manual_visible,
+                force_settings,
                 #[cfg(target_os = "macos")]
                 macos_maximized: false,
                 file_dialog: egui_file_dialog::FileDialog::new(),
@@ -62,7 +66,14 @@ impl OverlayApp {
                 },
                 pending_connect: None,
             },
+        };
+
+        if let Some(spec) = app.settings.active.last_connection.clone() {
+            app.begin_connect_with_spec(spec);
+            app.ui.settings_visible = false;
         }
+
+        app
     }
 
     fn sync_mouse_passthrough(&mut self, ctx: &egui::Context) {
@@ -113,7 +124,7 @@ impl eframe::App for OverlayApp {
         let ctx = ui.ctx();
 
         // On macOS, with_maximized(true) doesn't work for undecorated transparent
-        // windows. Explicitly size the window to fill the monitor on the first frame.
+        // Explicitly size the window to fill the monitor on the first frame.
         #[cfg(target_os = "macos")]
         if !self.ui.macos_maximized {
             if let Some(monitor_size) = ctx.input(|i| i.viewport().monitor_size) {
@@ -123,7 +134,12 @@ impl eframe::App for OverlayApp {
             }
         }
 
+        if self.ui.force_settings.swap(false, std::sync::atomic::Ordering::Relaxed) {
+            self.ui.settings_visible = true;
+        }
+
         self.poll_connect_result();
+
         self.apply_live_visual_settings();
         self.apply_live_layout_settings();
         self.ui.file_dialog.update(ctx);

--- a/src/overlay_window/connection_flow.rs
+++ b/src/overlay_window/connection_flow.rs
@@ -3,6 +3,7 @@ use super::OverlayApp;
 use crate::connection::{ConnectedState, ConnectionRequest, ConnectionTask};
 use crate::device_discovery::DeviceKind;
 use crate::protocols::{ConnectionSpec, ZmkTransportConfig};
+use std::sync::atomic::Ordering;
 
 impl OverlayApp {
     pub(super) fn select_device(&mut self, index: usize) {
@@ -92,17 +93,16 @@ impl OverlayApp {
         self.session.active_layout_name = connected.selected_layout_name.clone();
         self.session.draft_layout_name = connected.selected_layout_name;
         self.session.connected_definition = Some(connected.definition);
-        self.session.connection = AppConnectionState::Connected {
-            keyboard: connected.keyboard,
-        };
-        self.session.ever_connected = true;
+
+        let keyboard = connected.keyboard;
+        keyboard
+            .show_on_layer_change
+            .store(self.settings.active.show_on_layer_change, Ordering::SeqCst);
+
+        self.session.connection = AppConnectionState::Connected { keyboard };
+        self.session.has_connected = true;
         self.ui.settings_error = None;
         self.ui.settings_warning = None;
-
-        if let AppConnectionState::Connected { keyboard } = &self.session.connection {
-            *keyboard.show_on_layer_change.lock().unwrap() =
-                self.settings.active.show_on_layer_change;
-        }
 
         self.settings.active.last_connection = Some(connected.spec);
         self.settings.draft.last_connection = self.settings.active.last_connection.clone();
@@ -115,7 +115,7 @@ impl OverlayApp {
         self.session.active_layout_name.clear();
         self.session.draft_layout_name.clear();
         self.session.connected_definition = None;
-        self.session.ever_connected = false;
+        self.session.has_connected = false;
 
         self.settings.active.last_connection = None;
         self.settings.draft.last_connection = None;

--- a/src/overlay_window/connection_flow.rs
+++ b/src/overlay_window/connection_flow.rs
@@ -155,7 +155,11 @@ impl OverlayApp {
             layout_name: None,
         };
 
-        self.connect.pending_connect = Some(ConnectionTask::start(request, self.ui_wake.clone()));
+        self.connect.pending_connect = Some(ConnectionTask::start(
+            request,
+            self.ui_wake.clone(),
+            self.ui.manual_visible.clone(),
+        ));
         self.ui.settings_error = None;
     }
 
@@ -182,7 +186,11 @@ impl OverlayApp {
             },
         };
 
-        self.connect.pending_connect = Some(ConnectionTask::start(request, self.ui_wake.clone()));
+        self.connect.pending_connect = Some(ConnectionTask::start(
+            request,
+            self.ui_wake.clone(),
+            self.ui.manual_visible.clone(),
+        ));
         self.ui.settings_error = None;
     }
 

--- a/src/overlay_window/connection_flow.rs
+++ b/src/overlay_window/connection_flow.rs
@@ -99,6 +99,13 @@ impl OverlayApp {
         self.ui.settings_error = None;
         self.ui.settings_warning = None;
 
+        if let AppConnectionState::Connected { keyboard } = &self.session.connection {
+            *keyboard.show_on_layer_change.lock().unwrap() =
+                self.settings.active.show_on_layer_change;
+        }
+
+        self.settings.active.last_connection = Some(connected.spec);
+        self.settings.draft.last_connection = self.settings.active.last_connection.clone();
         self.persist_settings();
     }
 
@@ -133,6 +140,21 @@ impl OverlayApp {
         }
 
         self.begin_connect_with_current_draft();
+    }
+
+    pub(super) fn begin_connect_with_spec(&mut self, spec: ConnectionSpec) {
+        if self.connect.pending_connect.is_some() {
+            return;
+        }
+
+        let request = ConnectionRequest {
+            spec,
+            timeout: self.settings.draft.timeout,
+            layout_name: None,
+        };
+
+        self.connect.pending_connect = Some(ConnectionTask::start(request, self.ui_wake.clone()));
+        self.ui.settings_error = None;
     }
 
     fn begin_connect_with_current_draft(&mut self) {

--- a/src/overlay_window/connection_flow.rs
+++ b/src/overlay_window/connection_flow.rs
@@ -109,6 +109,19 @@ impl OverlayApp {
         self.persist_settings();
     }
 
+    pub(super) fn disconnect(&mut self) {
+        self.session.connection = AppConnectionState::Disconnected;
+        self.session.layout_names.clear();
+        self.session.active_layout_name.clear();
+        self.session.draft_layout_name.clear();
+        self.session.connected_definition = None;
+        self.session.ever_connected = false;
+
+        self.settings.active.last_connection = None;
+        self.settings.draft.last_connection = None;
+        self.persist_settings();
+    }
+
     pub(super) fn persist_settings(&self) {
         if let Err(e) = self.settings.active.save() {
             eprintln!("Failed to save settings: {e}");
@@ -116,17 +129,6 @@ impl OverlayApp {
     }
 
     pub(super) fn connect_from_ui(&mut self) {
-        if matches!(
-            self.session.connection,
-            AppConnectionState::Connected { .. }
-        ) {
-            self.ui.settings_warning = Some(
-                "Switching device/protocol/layout requires app restart in this version."
-                    .to_string(),
-            );
-            return;
-        }
-
         if self.connect.selected_device_index.is_none() {
             self.ui.settings_error = Some("No device selected".to_string());
             return;

--- a/src/overlay_window/settings_sync.rs
+++ b/src/overlay_window/settings_sync.rs
@@ -15,7 +15,9 @@ impl OverlayApp {
             || self.settings.active.margin != self.settings.draft.margin
             || self.settings.active.position != self.settings.draft.position
             || self.settings.active.timeout != self.settings.draft.timeout
-            || self.settings.active.theme != self.settings.draft.theme;
+            || self.settings.active.theme != self.settings.draft.theme
+            || self.settings.active.show_on_layer_change
+                != self.settings.draft.show_on_layer_change;
 
         if !changed {
             return;
@@ -29,11 +31,14 @@ impl OverlayApp {
         self.settings.active.position = self.settings.draft.position;
         self.settings.active.timeout = self.settings.draft.timeout;
         self.settings.active.theme = self.settings.draft.theme.clone();
+        self.settings.active.show_on_layer_change = self.settings.draft.show_on_layer_change;
 
         if let AppConnectionState::Connected { keyboard } = &self.session.connection {
             if old_timeout != self.settings.active.timeout {
                 keyboard.set_timeout(self.settings.active.timeout);
             }
+            *keyboard.show_on_layer_change.lock().unwrap() =
+                self.settings.active.show_on_layer_change;
         }
 
         self.persist_settings();
@@ -125,7 +130,22 @@ impl OverlayApp {
                 if self.ui.settings_visible {
                     true
                 } else {
-                    match keyboard.time_to_hide_overlay.lock().unwrap().as_ref() {
+                    let manual = self
+                        .ui
+                        .manual_visible
+                        .load(std::sync::atomic::Ordering::Relaxed);
+
+                    if !self.settings.active.show_on_layer_change {
+                        // eprintln!("Debug: show_on_layer_change=false, manual={}", manual);
+                        return manual;
+                    }
+
+                    if manual {
+                        return true;
+                    }
+
+                    let time_to_hide_guard = keyboard.time_to_hide_overlay.lock().unwrap();
+                    match time_to_hide_guard.as_ref() {
                         Some(time_to_hide) => Instant::now() < *time_to_hide,
                         None => true,
                     }

--- a/src/overlay_window/settings_sync.rs
+++ b/src/overlay_window/settings_sync.rs
@@ -2,6 +2,7 @@ use super::state::AppConnectionState;
 use super::OverlayApp;
 use crate::settings::{ProtocolType, WindowPosition};
 use eframe::egui::{self, Align2};
+use std::sync::atomic::Ordering;
 use std::time::Instant;
 
 impl OverlayApp {
@@ -37,8 +38,9 @@ impl OverlayApp {
             if old_timeout != self.settings.active.timeout {
                 keyboard.set_timeout(self.settings.active.timeout);
             }
-            *keyboard.show_on_layer_change.lock().unwrap() =
-                self.settings.active.show_on_layer_change;
+            keyboard
+                .show_on_layer_change
+                .store(self.settings.active.show_on_layer_change, Ordering::SeqCst);
         }
 
         self.persist_settings();
@@ -136,7 +138,6 @@ impl OverlayApp {
                         .load(std::sync::atomic::Ordering::Relaxed);
 
                     if !self.settings.active.show_on_layer_change {
-                        // eprintln!("Debug: show_on_layer_change=false, manual={}", manual);
                         return manual;
                     }
 

--- a/src/overlay_window/state.rs
+++ b/src/overlay_window/state.rs
@@ -62,7 +62,7 @@ pub struct SettingsState {
 
 pub struct SessionState {
     pub connection: AppConnectionState,
-    pub ever_connected: bool,
+    pub has_connected: bool,
     pub connected_definition: Option<KeyboardDefinition>,
     pub layout_names: Vec<String>,
     pub active_layout_name: String,

--- a/src/overlay_window/state.rs
+++ b/src/overlay_window/state.rs
@@ -12,6 +12,7 @@ use egui_file_dialog::FileDialog;
 pub struct LabelGalleys {
     pub symbol: Option<std::sync::Arc<egui::Galley>>,
     pub text: Option<std::sync::Arc<egui::Galley>>,
+    pub hold: Option<std::sync::Arc<egui::Galley>>,
 }
 
 pub enum AppConnectionState {

--- a/src/overlay_window/state.rs
+++ b/src/overlay_window/state.rs
@@ -3,6 +3,8 @@ use crate::device_discovery::DiscoveredDevice;
 use crate::keyboard::Keyboard;
 use crate::protocols::KeyboardDefinition;
 use crate::settings::{ProtocolType, Settings};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use eframe::egui;
 use egui_file_dialog::FileDialog;
@@ -45,6 +47,8 @@ pub struct UiState {
     pub settings_error: Option<String>,
     pub settings_warning: Option<String>,
     pub mouse_passthrough: Option<bool>,
+    pub manual_visible: Arc<AtomicBool>,
+    pub force_settings: Arc<AtomicBool>,
     #[cfg(target_os = "macos")]
     pub macos_maximized: bool,
     pub file_dialog: FileDialog,

--- a/src/overlay_window/ui_overlay.rs
+++ b/src/overlay_window/ui_overlay.rs
@@ -215,7 +215,6 @@ impl OverlayApp {
         pressed: bool,
     ) -> (egui::Color32, egui::Color32, f32, egui::Color32) {
         const DESATURATE_FACTOR: f32 = 0.7;
-
         const BLACK: egui::Color32 = egui::Color32::BLACK;
 
         let size = self.settings.active.size as f32;
@@ -223,19 +222,19 @@ impl OverlayApp {
         let mut background_color = Self::to_egui_color(layer_theme_color);
         let mut font_color = Self::to_egui_color(self.settings.active.theme.font_color);
 
-        if pressed {
-            return (
-                background_color.lerp_to_gamma(egui::Color32::WHITE, 0.2),
-                background_color.lerp_to_gamma(egui::Color32::WHITE, 0.7),
-                0.03 * size,
-                font_color.lerp_to_gamma(egui::Color32::WHITE, 0.4),
-            );
-        }
-
         if kind == KeycodeKind::Special {
             background_color = background_color.lerp_to_gamma(BLACK, 0.6);
         } else if kind == KeycodeKind::Modifier {
             background_color = background_color.lerp_to_gamma(BLACK, 0.3);
+        }
+
+        if pressed {
+            return (
+                background_color.lerp_to_gamma(egui::Color32::WHITE, 0.25),
+                background_color.lerp_to_gamma(egui::Color32::WHITE, 0.8),
+                0.08 * size,
+                font_color.lerp_to_gamma(egui::Color32::WHITE, 0.5),
+            );
         }
 
         let mut border_color = background_color.lerp_to_gamma(BLACK, 0.2);

--- a/src/overlay_window/ui_overlay.rs
+++ b/src/overlay_window/ui_overlay.rs
@@ -296,15 +296,10 @@ impl OverlayApp {
                         .get_key(effective_layer as usize, key.row, key.col)
                         .unwrap_or_default();
 
-                    let first_layer_key_kind = keyboard
-                        .get_key(0, key.row, key.col)
-                        .map(|k| k.kind)
-                        .unwrap_or(KeycodeKind::Basic);
-
                     let (fill_color, stroke_color, border_thickness, font_color) = self
                         .get_keycode_color(
                             layout_key.layer_ref.unwrap_or(effective_layer),
-                            first_layer_key_kind,
+                            layout_key.kind,
                             is_background_key,
                             keyboard.is_key_pressed(key.row, key.col),
                         );

--- a/src/overlay_window/ui_overlay.rs
+++ b/src/overlay_window/ui_overlay.rs
@@ -35,7 +35,12 @@ impl OverlayApp {
                     text_shape.pos = rotate_point(text_shape.pos, origin, angle);
                     text_shape.angle += angle;
                 }
-                _ => {}
+                _ => {
+                    eprintln!(
+                        "Warning: Unhandled shape type in add_rotated_shape: {:?}",
+                        shape
+                    );
+                }
             }
         }
         painter.add(shape);
@@ -162,7 +167,6 @@ impl OverlayApp {
                         hold: None,
                     }
                 } else {
-                    let mut found = false;
                     let mut text_galley = None;
                     while truncated.len() > 1 {
                         truncated.pop();
@@ -170,22 +174,13 @@ impl OverlayApp {
                         let truncated_galley = create_galley(truncated_with_ellipsis, font.clone());
                         if fits_width(&truncated_galley, max_width) {
                             text_galley = Some(truncated_galley);
-                            found = true;
                             break;
                         }
                     }
-                    if found {
-                        LabelGalleys {
-                            symbol: None,
-                            text: text_galley,
-                            hold: None,
-                        }
-                    } else {
-                        LabelGalleys {
-                            symbol: None,
-                            text: None,
-                            hold: None,
-                        }
+                    LabelGalleys {
+                        symbol: None,
+                        text: text_galley,
+                        hold: None,
                     }
                 }
             }
@@ -344,7 +339,7 @@ impl OverlayApp {
                             egui::pos2(rect.left(), rect.bottom() - rect.height() * 0.22),
                             rect.max,
                         );
-                        let r = (0.08 * size) as u8;
+                        let r = ((0.08 * size).clamp(0.0, 255.0)) as u8;
 
                         Self::add_rotated_shape(
                             ui.painter(),

--- a/src/overlay_window/ui_overlay.rs
+++ b/src/overlay_window/ui_overlay.rs
@@ -16,8 +16,20 @@ impl OverlayApp {
     ) -> LabelGalleys {
         let size = self.settings.active.size as f32;
         let font_scale = self.settings.active.font_size_multiplier;
-        let create_galley =
-            |text: String, fid: egui::FontId| ui.painter().layout_no_wrap(text, fid, color);
+        let create_galley = |text: String, fid: egui::FontId| {
+            let mut job = egui::text::LayoutJob::default();
+            job.append(
+                &text,
+                0.0,
+                egui::text::TextFormat {
+                    font_id: fid,
+                    color,
+                    ..Default::default()
+                },
+            );
+            job.halign = egui::Align::Center;
+            ui.painter().layout_job(job)
+        };
         let fits_width =
             |galley: &std::sync::Arc<egui::Galley>, max: f32| galley.rect.width() <= max;
         let max_width = rect.width() * 0.85;

--- a/src/overlay_window/ui_overlay.rs
+++ b/src/overlay_window/ui_overlay.rs
@@ -22,7 +22,7 @@ impl OverlayApp {
             |galley: &std::sync::Arc<egui::Galley>, max: f32| galley.rect.width() <= max;
         let max_width = rect.width() * 0.85;
 
-        if let Some(symbol) = &key.symbol {
+        let mut galleys = if let Some(symbol) = &key.symbol {
             let symbol_font = egui::FontId::proportional(0.33 * size * font_scale);
             let symbol_galley = create_galley(symbol.clone(), symbol_font);
 
@@ -31,91 +31,134 @@ impl OverlayApp {
                 let gap = 0.06 * size;
                 let total_width = symbol_galley.rect.width() + gap + text_galley.rect.width();
                 if total_width <= max_width {
-                    return LabelGalleys {
+                    LabelGalleys {
                         symbol: Some(symbol_galley),
                         text: Some(text_galley),
-                    };
+                        hold: None,
+                    }
+                } else {
+                    if let Some(short) = &key.tap.short {
+                        let text_galley = create_galley(short.clone(), font.clone());
+                        let gap = 0.06 * size;
+                        let total_width =
+                            symbol_galley.rect.width() + gap + text_galley.rect.width();
+                        if total_width <= max_width {
+                            LabelGalleys {
+                                symbol: Some(symbol_galley),
+                                text: Some(text_galley),
+                                hold: None,
+                            }
+                        } else {
+                            LabelGalleys {
+                                symbol: Some(symbol_galley),
+                                text: None,
+                                hold: None,
+                            }
+                        }
+                    } else {
+                        LabelGalleys {
+                            symbol: Some(symbol_galley),
+                            text: None,
+                            hold: None,
+                        }
+                    }
+                }
+            } else {
+                LabelGalleys {
+                    symbol: Some(symbol_galley),
+                    text: None,
+                    hold: None,
                 }
             }
-
-            if let Some(short) = &key.tap.short {
-                let text_galley = create_galley(short.clone(), font.clone());
-                let gap = 0.06 * size;
-                let total_width = symbol_galley.rect.width() + gap + text_galley.rect.width();
-                if total_width <= max_width {
-                    return LabelGalleys {
-                        symbol: Some(symbol_galley),
-                        text: Some(text_galley),
-                    };
-                }
-            }
-
-            return LabelGalleys {
-                symbol: Some(symbol_galley),
-                text: None,
-            };
-        }
-
-        let full_galley = create_galley(key.tap.full.clone(), font.clone());
-        if fits_width(&full_galley, max_width) {
-            return LabelGalleys {
-                symbol: None,
-                text: Some(full_galley),
-            };
-        }
-
-        let mut truncated = if let Some(short) = &key.tap.short {
-            let short_galley = create_galley(short.clone(), font.clone());
-            if fits_width(&short_galley, max_width) {
-                return LabelGalleys {
-                    symbol: None,
-                    text: Some(short_galley),
-                };
-            }
-            short.clone()
         } else {
-            key.tap.full.clone()
+            let full_galley = create_galley(key.tap.full.clone(), font.clone());
+            if fits_width(&full_galley, max_width) {
+                LabelGalleys {
+                    symbol: None,
+                    text: Some(full_galley),
+                    hold: None,
+                }
+            } else {
+                let mut truncated = if let Some(short) = &key.tap.short {
+                    let short_galley = create_galley(short.clone(), font.clone());
+                    if fits_width(&short_galley, max_width) {
+                        return LabelGalleys {
+                            symbol: None,
+                            text: Some(short_galley),
+                            hold: None,
+                        };
+                    }
+                    short.clone()
+                } else {
+                    key.tap.full.clone()
+                };
+
+                if self.settings.active.auto_fit_before_ellipsis {
+                    let max_height = rect.height() * 0.85;
+                    let fit_text = key.tap.short.as_ref().unwrap_or(&key.tap.full).clone();
+                    let fit_galley = create_galley(fit_text.clone(), font.clone());
+                    let width_scale = if fit_galley.rect.width() > 0.0 {
+                        max_width / fit_galley.rect.width()
+                    } else {
+                        1.0
+                    };
+                    let height_scale = if fit_galley.rect.height() > 0.0 {
+                        max_height / fit_galley.rect.height()
+                    } else {
+                        1.0
+                    };
+                    let scale = width_scale.min(height_scale).min(1.0);
+                    let fitted_text =
+                        create_galley(fit_text, egui::FontId::proportional(font.size * scale));
+                    LabelGalleys {
+                        symbol: None,
+                        text: Some(fitted_text),
+                        hold: None,
+                    }
+                } else {
+                    let mut found = false;
+                    let mut text_galley = None;
+                    while truncated.len() > 1 {
+                        truncated.pop();
+                        let truncated_with_ellipsis = format!("{}...", truncated);
+                        let truncated_galley = create_galley(truncated_with_ellipsis, font.clone());
+                        if fits_width(&truncated_galley, max_width) {
+                            text_galley = Some(truncated_galley);
+                            found = true;
+                            break;
+                        }
+                    }
+                    if found {
+                        LabelGalleys {
+                            symbol: None,
+                            text: text_galley,
+                            hold: None,
+                        }
+                    } else {
+                        LabelGalleys {
+                            symbol: None,
+                            text: None,
+                            hold: None,
+                        }
+                    }
+                }
+            }
         };
 
-        if self.settings.active.auto_fit_before_ellipsis {
-            let max_height = rect.height() * 0.85;
-            let fit_text = key.tap.short.as_ref().unwrap_or(&key.tap.full).clone();
-            let fit_galley = create_galley(fit_text.clone(), font.clone());
-            let width_scale = if fit_galley.rect.width() > 0.0 {
-                max_width / fit_galley.rect.width()
-            } else {
-                1.0
-            };
-            let height_scale = if fit_galley.rect.height() > 0.0 {
-                max_height / fit_galley.rect.height()
-            } else {
-                1.0
-            };
-            let scale = width_scale.min(height_scale).min(1.0);
-            let fitted_text =
-                create_galley(fit_text, egui::FontId::proportional(font.size * scale));
-            return LabelGalleys {
-                symbol: None,
-                text: Some(fitted_text),
-            };
-        }
-
-        while truncated.len() > 1 {
-            truncated.pop();
-            let truncated_with_ellipsis = format!("{}...", truncated);
-            let truncated_galley = create_galley(truncated_with_ellipsis, font.clone());
-            if fits_width(&truncated_galley, max_width) {
-                return LabelGalleys {
-                    symbol: None,
-                    text: Some(truncated_galley),
-                };
+        if let Some(hold) = &key.hold {
+            let hold_font = egui::FontId::proportional(0.20 * size * font_scale);
+            let hold_galley = create_galley(hold.full.clone(), hold_font.clone());
+            if fits_width(&hold_galley, max_width) {
+                galleys.hold = Some(hold_galley);
+            } else if let Some(short) = &hold.short {
+                let short_galley = create_galley(short.clone(), hold_font);
+                if fits_width(&short_galley, max_width) {
+                    galleys.hold = Some(short_galley);
+                }
             }
         }
 
-        LabelGalleys {
-            symbol: None,
-            text: None,
-        }
+        galleys
     }
 
     pub(super) fn get_keycode_color(
@@ -236,40 +279,69 @@ impl OverlayApp {
                     );
 
                     let font = egui::FontId::proportional(0.25 * size * font_scale);
-                    match self.generate_key_label_galleys(ui, &layout_key, rect, font, font_color) {
-                        LabelGalleys {
-                            symbol: Some(symbol_galley),
-                            text: Some(text_galley),
-                        } => {
+                    let galleys =
+                        self.generate_key_label_galleys(ui, &layout_key, rect, font, font_color);
+
+                    let main_label_rect = if galleys.hold.is_some() {
+                        egui::Rect::from_min_max(
+                            rect.left_top(),
+                            egui::pos2(rect.right(), rect.bottom() - rect.height() * 0.22),
+                        )
+                    } else {
+                        rect
+                    };
+
+                    if let Some(hold_galley) = galleys.hold {
+                        let hold_area_rect = egui::Rect::from_min_max(
+                            egui::pos2(rect.left(), rect.bottom() - rect.height() * 0.22),
+                            rect.max,
+                        );
+                        let r = (0.08 * size) as u8;
+                        ui.painter().rect_filled(
+                            hold_area_rect,
+                            egui::CornerRadius {
+                                nw: 0,
+                                ne: 0,
+                                sw: r,
+                                se: r,
+                            },
+                            fill_color.lerp_to_gamma(egui::Color32::BLACK, 0.15),
+                        );
+                        let hold_pos = hold_area_rect.center() - hold_galley.rect.center().to_vec2();
+                        ui.painter().galley(
+                            hold_pos,
+                            hold_galley,
+                            font_color.gamma_multiply(0.7),
+                        );
+                    }
+
+                    match (galleys.symbol, galleys.text) {
+                        (Some(symbol_galley), Some(text_galley)) => {
                             let gap = 0.06 * size;
                             let total_width =
                                 symbol_galley.rect.width() + gap + text_galley.rect.width();
-                            let start_x = rect.center().x - total_width * 0.5;
+                            let start_x = main_label_rect.center().x - total_width * 0.5;
 
                             let text_pos_x = start_x + gap + symbol_galley.rect.width();
                             let text_pos = egui::pos2(
                                 text_pos_x,
-                                rect.center().y - text_galley.rect.center().y,
+                                main_label_rect.center().y - text_galley.rect.center().y,
                             );
                             let sym_pos = egui::pos2(
                                 start_x,
-                                rect.center().y - symbol_galley.rect.center().y,
+                                main_label_rect.center().y - symbol_galley.rect.center().y,
                             );
                             ui.painter().galley(sym_pos, symbol_galley, font_color);
                             ui.painter().galley(text_pos, text_galley, font_color);
                         }
-                        LabelGalleys {
-                            symbol: Some(symbol_galley),
-                            text: None,
-                        } => {
-                            let sym_pos = rect.center() - symbol_galley.rect.center().to_vec2();
+                        (Some(symbol_galley), None) => {
+                            let sym_pos =
+                                main_label_rect.center() - symbol_galley.rect.center().to_vec2();
                             ui.painter().galley(sym_pos, symbol_galley, font_color);
                         }
-                        LabelGalleys {
-                            symbol: None,
-                            text: Some(text_galley),
-                        } => {
-                            let label_pos = rect.center() - text_galley.rect.center().to_vec2();
+                        (None, Some(text_galley)) => {
+                            let label_pos =
+                                main_label_rect.center() - text_galley.rect.center().to_vec2();
                             ui.painter().galley(label_pos, text_galley, font_color);
                         }
                         _ => {}

--- a/src/overlay_window/ui_overlay.rs
+++ b/src/overlay_window/ui_overlay.rs
@@ -5,7 +5,41 @@ use crate::layout_key::{KeycodeKind, LayoutKey};
 use crate::settings::ThemeColor;
 use eframe::egui::{self, Window};
 
+fn rotate_point(point: egui::Pos2, origin: egui::Pos2, angle_rad: f32) -> egui::Pos2 {
+    let cos_a = angle_rad.cos();
+    let sin_a = angle_rad.sin();
+    let dx = point.x - origin.x;
+    let dy = point.y - origin.y;
+    egui::pos2(
+        origin.x + dx * cos_a - dy * sin_a,
+        origin.y + dx * sin_a + dy * cos_a,
+    )
+}
+
 impl OverlayApp {
+    fn add_rotated_shape(
+        painter: &egui::Painter,
+        mut shape: egui::Shape,
+        angle: f32,
+        origin: egui::Pos2,
+    ) {
+        if angle != 0.0 {
+            match &mut shape {
+                egui::Shape::Rect(rect_shape) => {
+                    let new_center = rotate_point(rect_shape.rect.center(), origin, angle);
+                    rect_shape.rect =
+                        egui::Rect::from_center_size(new_center, rect_shape.rect.size());
+                    rect_shape.angle += angle;
+                }
+                egui::Shape::Text(text_shape) => {
+                    text_shape.pos = rotate_point(text_shape.pos, origin, angle);
+                    text_shape.angle += angle;
+                }
+                _ => {}
+            }
+        }
+        painter.add(shape);
+    }
     pub(super) fn generate_key_label_galleys(
         &self,
         ui: &egui::Ui,
@@ -282,12 +316,20 @@ impl OverlayApp {
                     )
                     .shrink(0.06 * size);
 
-                    ui.painter().rect(
-                        rect,
-                        0.1 * size,
-                        fill_color,
-                        egui::Stroke::new(border_thickness, stroke_color),
-                        egui::StrokeKind::Outside,
+                    let angle = key.r.to_radians();
+                    let origin = rect.center();
+
+                    Self::add_rotated_shape(
+                        ui.painter(),
+                        egui::Shape::Rect(egui::epaint::RectShape::new(
+                            rect,
+                            0.1 * size,
+                            fill_color,
+                            egui::Stroke::new(border_thickness, stroke_color),
+                            egui::StrokeKind::Outside,
+                        )),
+                        angle,
+                        origin,
                     );
 
                     let font = egui::FontId::proportional(0.25 * size * font_scale);
@@ -309,21 +351,35 @@ impl OverlayApp {
                             rect.max,
                         );
                         let r = (0.08 * size) as u8;
-                        ui.painter().rect_filled(
-                            hold_area_rect,
-                            egui::CornerRadius {
-                                nw: 0,
-                                ne: 0,
-                                sw: r,
-                                se: r,
-                            },
-                            fill_color.lerp_to_gamma(egui::Color32::BLACK, 0.15),
+
+                        Self::add_rotated_shape(
+                            ui.painter(),
+                            egui::Shape::Rect(egui::epaint::RectShape::new(
+                                hold_area_rect,
+                                egui::CornerRadius {
+                                    nw: 0,
+                                    ne: 0,
+                                    sw: r,
+                                    se: r,
+                                },
+                                fill_color.lerp_to_gamma(egui::Color32::BLACK, 0.15),
+                                egui::Stroke::NONE,
+                                egui::StrokeKind::Outside,
+                            )),
+                            angle,
+                            origin,
                         );
+
                         let hold_pos = hold_area_rect.center() - hold_galley.rect.center().to_vec2();
-                        ui.painter().galley(
-                            hold_pos,
-                            hold_galley,
-                            font_color.gamma_multiply(0.7),
+                        Self::add_rotated_shape(
+                            ui.painter(),
+                            egui::Shape::Text(egui::epaint::TextShape::new(
+                                hold_pos,
+                                hold_galley,
+                                font_color.gamma_multiply(0.7),
+                            )),
+                            angle,
+                            origin,
                         );
                     }
 
@@ -343,18 +399,54 @@ impl OverlayApp {
                                 start_x,
                                 main_label_rect.center().y - symbol_galley.rect.center().y,
                             );
-                            ui.painter().galley(sym_pos, symbol_galley, font_color);
-                            ui.painter().galley(text_pos, text_galley, font_color);
+                            Self::add_rotated_shape(
+                                ui.painter(),
+                                egui::Shape::Text(egui::epaint::TextShape::new(
+                                    sym_pos,
+                                    symbol_galley,
+                                    font_color,
+                                )),
+                                angle,
+                                origin,
+                            );
+                            Self::add_rotated_shape(
+                                ui.painter(),
+                                egui::Shape::Text(egui::epaint::TextShape::new(
+                                    text_pos,
+                                    text_galley,
+                                    font_color,
+                                )),
+                                angle,
+                                origin,
+                            );
                         }
                         (Some(symbol_galley), None) => {
                             let sym_pos =
                                 main_label_rect.center() - symbol_galley.rect.center().to_vec2();
-                            ui.painter().galley(sym_pos, symbol_galley, font_color);
+                            Self::add_rotated_shape(
+                                ui.painter(),
+                                egui::Shape::Text(egui::epaint::TextShape::new(
+                                    sym_pos,
+                                    symbol_galley,
+                                    font_color,
+                                )),
+                                angle,
+                                origin,
+                            );
                         }
                         (None, Some(text_galley)) => {
                             let label_pos =
                                 main_label_rect.center() - text_galley.rect.center().to_vec2();
-                            ui.painter().galley(label_pos, text_galley, font_color);
+                            Self::add_rotated_shape(
+                                ui.painter(),
+                                egui::Shape::Text(egui::epaint::TextShape::new(
+                                    label_pos,
+                                    text_galley,
+                                    font_color,
+                                )),
+                                angle,
+                                origin,
+                            );
                         }
                         _ => {}
                     }

--- a/src/overlay_window/ui_settings.rs
+++ b/src/overlay_window/ui_settings.rs
@@ -236,6 +236,13 @@ impl OverlayApp {
                                 "Fit long labels to available space",
                             );
                             ui.end_row();
+
+                            ui.label("Show on layer change");
+                            ui.checkbox(
+                                &mut self.settings.draft.show_on_layer_change,
+                                "Automatically show overlay when switching layers",
+                            );
+                            ui.end_row();
                         });
                 });
 

--- a/src/overlay_window/ui_settings.rs
+++ b/src/overlay_window/ui_settings.rs
@@ -58,12 +58,12 @@ impl OverlayApp {
                         .spacing([20.0, 10.0])
                         .show(ui, |ui| {
                             ui.label("Device");
-                            ui.add_enabled_ui(!connection_locked, |ui| {
-                                ui.horizontal(|ui| {
-                                    let combo_width = (ui.available_width()
-                                        - RIGHT_COLUMN_WIDTH
-                                        - control_spacing)
-                                        .max(120.0);
+                            ui.horizontal(|ui| {
+                                let combo_width = (ui.available_width()
+                                    - RIGHT_COLUMN_WIDTH
+                                    - control_spacing)
+                                    .max(120.0);
+                                ui.add_enabled_ui(!connection_locked, |ui| {
                                     egui::ComboBox::from_id_salt("device_combo")
                                         .width(combo_width)
                                         .selected_text(selected_device_text.clone())
@@ -86,15 +86,27 @@ impl OverlayApp {
                                                 ui.weak("No devices found");
                                             }
                                         });
+                                });
 
-                                    ui.allocate_ui_with_layout(
-                                        egui::vec2(RIGHT_COLUMN_WIDTH, 20.0),
-                                        egui::Layout::left_to_right(egui::Align::Center),
-                                        |ui| {
-                                            let connect_in_progress =
-                                                self.connect.pending_connect.is_some();
-                                            let can_connect = !connection_locked
-                                                && !connect_in_progress
+                                ui.allocate_ui_with_layout(
+                                    egui::vec2(RIGHT_COLUMN_WIDTH, 20.0),
+                                    egui::Layout::left_to_right(egui::Align::Center),
+                                    |ui| {
+                                        let connect_in_progress =
+                                            self.connect.pending_connect.is_some();
+
+                                        if connection_locked {
+                                            if ui
+                                                .add_sized(
+                                                    [RIGHT_COLUMN_WIDTH, 20.0],
+                                                    egui::Button::new("Disconnect"),
+                                                )
+                                                .clicked()
+                                            {
+                                                self.disconnect();
+                                            }
+                                        } else {
+                                            let can_connect = !connect_in_progress
                                                 && self.connect.selected_device_index.is_some();
                                             let button_label = if connect_in_progress {
                                                 "Connecting..."
@@ -112,9 +124,9 @@ impl OverlayApp {
                                                     self.connect_from_ui();
                                                 }
                                             });
-                                        },
-                                    );
-                                });
+                                        }
+                                    },
+                                );
                             });
                             ui.end_row();
 

--- a/src/overlay_window/ui_settings.rs
+++ b/src/overlay_window/ui_settings.rs
@@ -331,7 +331,7 @@ impl OverlayApp {
 
         if self.ui.settings_visible && !open {
             self.ui.settings_visible = false;
-            if !self.session.ever_connected {
+            if !self.session.has_connected {
                 ctx.send_viewport_cmd(egui::ViewportCommand::Close);
             }
         }

--- a/src/protocols/kle_parser.rs
+++ b/src/protocols/kle_parser.rs
@@ -59,7 +59,7 @@ fn parse_kle_keymap(keymap: &[Value]) -> Result<Vec<Key>, Box<dyn Error>> {
     for row in keymap {
         let row_array = match row.as_array() {
             Some(arr) => arr,
-            None => continue, // Skip non-array rows
+            None => continue,
         };
 
         let mut current_x: f32 = 0.0;
@@ -68,19 +68,22 @@ fn parse_kle_keymap(keymap: &[Value]) -> Result<Vec<Key>, Box<dyn Error>> {
 
         for item in row_array {
             if let Some(obj) = item.as_object() {
-                // This is a key property object which modifies the next key
-
                 // Handle rotation properties (these persist until changed)
-                // When rx or ry changes, reset the current position to the rotation origin
+                let mut origin_changed = false;
                 if let Some(rx) = obj.get("rx").and_then(|v| v.as_f64()) {
                     rotation_x = rx as f32;
-                    current_x = 0.0; // Reset x relative to new rotation origin
-                    current_y = 0.0; // Reset y relative to new rotation origin
+                    origin_changed = true;
                 }
                 if let Some(ry) = obj.get("ry").and_then(|v| v.as_f64()) {
                     rotation_y = ry as f32;
-                    current_y = 0.0; // Reset y relative to new rotation origin
+                    origin_changed = true;
                 }
+
+                if origin_changed {
+                    current_x = 0.0;
+                    current_y = 0.0;
+                }
+
                 if let Some(r) = obj.get("r").and_then(|v| v.as_f64()) {
                     rotation_angle = r as f32;
                 }
@@ -98,11 +101,10 @@ fn parse_kle_keymap(keymap: &[Value]) -> Result<Vec<Key>, Box<dyn Error>> {
                     current_y += y as f32;
                 }
             } else if let Some(label) = item.as_str() {
-                // This is a key with a label
                 if let Some((row, col)) = parse_matrix_label(label) {
-                    // Normalize KLE-relative coordinates to absolute space, then flatten rotation.
                     let absolute_x = rotation_x + current_x;
                     let absolute_y = rotation_y + current_y;
+
                     let (final_x, final_y) = flattened_top_left_after_center_rotation(
                         absolute_x,
                         absolute_y,
@@ -120,21 +122,17 @@ fn parse_kle_keymap(keymap: &[Value]) -> Result<Vec<Key>, Box<dyn Error>> {
                         y: final_y,
                         w: current_w,
                         h: current_h,
+                        r: rotation_angle,
                     });
                 }
 
                 current_x += current_w;
-
                 current_w = 1.0;
                 current_h = 1.0;
             }
         }
 
-        // Only increment y for non-rotated keys.
-        // For rotated keys, y is relative to rotation origin.
-        if rotation_angle == 0.0 {
-            current_y += 1.0;
-        }
+        current_y += 1.0;
     }
 
     Ok(keys)

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -24,6 +24,8 @@ pub struct Key {
     pub y: f32,
     pub w: f32,
     pub h: f32,
+    #[serde(default)]
+    pub r: f32,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -78,13 +78,13 @@ pub trait KeyboardProtocol: Send {
     fn hid_read(&self) -> Result<Vec<u8>, Box<dyn Error>>;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ZmkTransportConfig {
     Serial(String),
     Ble(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ConnectionSpec {
     Via {
         json_path: String,

--- a/src/protocols/qmk_json_parser.rs
+++ b/src/protocols/qmk_json_parser.rs
@@ -142,6 +142,7 @@ fn collect_layout_keys(layout: &Value) -> Result<Vec<Key>, Box<dyn Error>> {
             y,
             w,
             h,
+            r: angle_deg,
         });
     }
 

--- a/src/protocols/zmk.rs
+++ b/src/protocols/zmk.rs
@@ -158,6 +158,7 @@ fn build_from_zmk_data(
                 y,
                 w,
                 h,
+                r: angle_deg,
             }
         })
         .collect();

--- a/src/qmk_keycode_labels/advanced.rs
+++ b/src/qmk_keycode_labels/advanced.rs
@@ -78,12 +78,12 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
             let mod_str = mod_value_to_string(mod_value);
 
             let keycode = (remainder & 0xFF) as u8;
-            let keycode_str = get_basic_layout_key(keycode as u16)
-                .map(|k| k.tap.full)
-                .unwrap_or_else(|| format!("0x{:02X}", keycode));
+            let tap_key = get_basic_layout_key(keycode as u16).unwrap_or_default();
 
             Some(LayoutKey {
-                tap: Label::new(format!("MT({},{})", mod_str, keycode_str)),
+                tap: tap_key.tap,
+                hold: Some(Label::new(mod_str)),
+                symbol: tap_key.symbol,
                 kind: KeycodeKind::Modifier,
                 ..Default::default()
             })
@@ -122,12 +122,12 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
             let layer = remainder >> 8;
 
             let keycode = (remainder & 0xFF) as u8;
-            let keycode_str = get_basic_layout_key(keycode as u16)
-                .map(|k| k.tap.full)
-                .unwrap_or_else(|| format!("0x{:02X}", keycode));
+            let tap_key = get_basic_layout_key(keycode as u16).unwrap_or_default();
 
             Some(LayoutKey {
-                tap: Label::new(format!("LT({},{})", layer, keycode_str)),
+                tap: tap_key.tap,
+                hold: Some(Label::new(format!("L{}", layer))),
+                symbol: tap_key.symbol,
                 kind: KeycodeKind::Modifier,
                 layer_ref: Some(layer as u8),
                 ..Default::default()
@@ -140,33 +140,33 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
 fn mod_value_to_string(mod_mask: u16) -> String {
     let mut mods = Vec::new();
     if mod_mask & MOD_LCTL != 0 {
-        mods.push("MOD_LCTL");
+        mods.push("Ctl");
     }
     if mod_mask & MOD_LSFT != 0 {
-        mods.push("MOD_LSFT");
+        mods.push("Sft");
     }
     if mod_mask & MOD_LALT != 0 {
-        mods.push("MOD_LALT");
+        mods.push("Alt");
     }
     if mod_mask & MOD_LGUI != 0 {
-        mods.push("MOD_LGUI");
+        mods.push("Gui");
     }
     if mod_mask & MOD_RCTL != 0 {
-        mods.push("MOD_RCTL");
+        mods.push("Ctl");
     }
     if mod_mask & MOD_RSFT != 0 {
-        mods.push("MOD_RSFT");
+        mods.push("Sft");
     }
     if mod_mask & MOD_RALT != 0 {
-        mods.push("MOD_RALT");
+        mods.push("Alt");
     }
     if mod_mask & MOD_RGUI != 0 {
-        mods.push("MOD_RGUI");
+        mods.push("Gui");
     }
 
     if mods.is_empty() {
         "None".to_string()
     } else {
-        mods.join(" | ")
+        mods.join("+")
     }
 }

--- a/src/qmk_keycode_labels/advanced.rs
+++ b/src/qmk_keycode_labels/advanced.rs
@@ -160,6 +160,12 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
 
 fn mod_value_to_string(mod_mask: u16) -> String {
     let mut mods = Vec::new();
+
+    // QMK uses a 5-bit format for many advanced keycodes:
+    // Bits 0-3: LCTL, LSFT, LALT, LGUI
+    // Bit 4: Right-side flag
+    // Since we use the same symbols for Left and Right, we only need to check bits 0-3.
+
     if mod_mask & MOD_LCTL != 0 {
         mods.push("\u{2388}");
     }
@@ -172,22 +178,13 @@ fn mod_value_to_string(mod_mask: u16) -> String {
     if mod_mask & MOD_LGUI != 0 {
         mods.push(egui_phosphor::fill::DIAMOND);
     }
-    if mod_mask & MOD_RCTL != 0 {
-        mods.push("\u{2388}");
-    }
-    if mod_mask & MOD_RSFT != 0 {
-        mods.push(egui_phosphor::regular::ARROW_FAT_UP);
-    }
-    if mod_mask & MOD_RALT != 0 {
-        mods.push(egui_phosphor::regular::OPTION);
-    }
-    if mod_mask & MOD_RGUI != 0 {
-        mods.push(egui_phosphor::fill::DIAMOND);
-    }
 
     if mods.is_empty() {
         "None".to_string()
     } else {
-        mods.into_iter().map(|s| s.to_string()).collect::<Vec<_>>().join("")
+        mods.into_iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join("")
     }
 }

--- a/src/qmk_keycode_labels/advanced.rs
+++ b/src/qmk_keycode_labels/advanced.rs
@@ -140,33 +140,33 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
 fn mod_value_to_string(mod_mask: u16) -> String {
     let mut mods = Vec::new();
     if mod_mask & MOD_LCTL != 0 {
-        mods.push("Ctl");
+        mods.push("\u{2388}");
     }
     if mod_mask & MOD_LSFT != 0 {
-        mods.push("Sft");
+        mods.push(egui_phosphor::regular::ARROW_FAT_UP);
     }
     if mod_mask & MOD_LALT != 0 {
-        mods.push("Alt");
+        mods.push(egui_phosphor::regular::OPTION);
     }
     if mod_mask & MOD_LGUI != 0 {
-        mods.push("Gui");
+        mods.push(egui_phosphor::fill::DIAMOND);
     }
     if mod_mask & MOD_RCTL != 0 {
-        mods.push("Ctl");
+        mods.push("\u{2388}");
     }
     if mod_mask & MOD_RSFT != 0 {
-        mods.push("Sft");
+        mods.push(egui_phosphor::regular::ARROW_FAT_UP);
     }
     if mod_mask & MOD_RALT != 0 {
-        mods.push("Alt");
+        mods.push(egui_phosphor::regular::OPTION);
     }
     if mod_mask & MOD_RGUI != 0 {
-        mods.push("Gui");
+        mods.push(egui_phosphor::fill::DIAMOND);
     }
 
     if mods.is_empty() {
         "None".to_string()
     } else {
-        mods.join("+")
+        mods.into_iter().map(|s| s.to_string()).collect::<Vec<_>>().join("")
     }
 }

--- a/src/qmk_keycode_labels/advanced.rs
+++ b/src/qmk_keycode_labels/advanced.rs
@@ -6,19 +6,40 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
     match keycode_bytes {
         input_bytes if QK_MODS.contains(&input_bytes) => {
             let keycode = input_bytes & 0xff;
-            let keycode_str = get_basic_layout_key(keycode)
-                .map(|k| k.tap.full)
-                .unwrap_or_else(|| format!("0x{:02X}", keycode));
+            let tap_key = get_basic_layout_key(keycode).unwrap_or_default();
+            let keycode_str = tap_key.tap.full.clone();
 
             let input_modifiers = input_bytes & 0x1f00;
+
+            // For pure shift modifiers, try to show the shifted character directly
+            if input_modifiers == QK_LSFT || input_modifiers == QK_RSFT {
+                if let Some(pos) = keycode_str.find('\n') {
+                    return Some(LayoutKey {
+                        tap: Label::new(keycode_str[..pos].to_string()),
+                        ..tap_key
+                    });
+                }
+            }
 
             // Try to find exact matches first
             if let Some((name, _)) = MODIFIER_KEY_TO_VALUE
                 .iter()
                 .find(|(_, v)| *v == input_modifiers)
             {
+                let mut display_name = name.to_string();
+                // Use our new symbols if it's a simple modifier
+                if input_modifiers == QK_LCTL || input_modifiers == QK_RCTL {
+                    display_name = "\u{2388}".to_string();
+                } else if input_modifiers == QK_LALT || input_modifiers == QK_RALT {
+                    display_name = egui_phosphor::regular::OPTION.to_string();
+                } else if input_modifiers == QK_LGUI || input_modifiers == QK_RGUI {
+                    display_name = egui_phosphor::fill::DIAMOND.to_string();
+                } else if input_modifiers == QK_LSFT || input_modifiers == QK_RSFT {
+                    display_name = egui_phosphor::regular::ARROW_FAT_UP.to_string();
+                }
+
                 return Some(LayoutKey {
-                    tap: Label::new(format!("{}({})", name, keycode_str)),
+                    tap: Label::new(format!("{}{}", display_name, keycode_str)),
                     kind: KeycodeKind::Modifier,
                     ..Default::default()
                 });
@@ -46,24 +67,24 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
                 .collect();
 
             if !enabled.is_empty() {
-                // Build nested parentheses style, e.g. LCTL(LALT(A))
-                let mut nested_mods = String::new();
-                for (i, part) in enabled.iter().enumerate() {
-                    if i > 0 {
-                        nested_mods.push('(');
-                    }
-                    nested_mods.push_str(part);
+                // Build compact symbol style, e.g. ⎈⌥A
+                let mut compact_label = String::new();
+                for part in enabled.iter() {
+                    let sym = match *part {
+                        "LCTL" | "RCTL" | "C" => "\u{2388}",
+                        "LSFT" | "RSFT" | "S" => egui_phosphor::regular::ARROW_FAT_UP,
+                        "LALT" | "RALT" | "A" | "ALGR" => egui_phosphor::regular::OPTION,
+                        "LGUI" | "RGUI" | "G" | "LCMD" | "LWIN" | "RCMD" | "RWIN" => {
+                            egui_phosphor::fill::DIAMOND
+                        }
+                        _ => *part,
+                    };
+                    compact_label.push_str(sym);
                 }
-                if !nested_mods.is_empty() {
-                    nested_mods.push('(');
-                }
-                nested_mods.push_str(&keycode_str);
-                for _ in 0..enabled.len() {
-                    nested_mods.push(')');
-                }
+                compact_label.push_str(&keycode_str);
 
                 return Some(LayoutKey {
-                    tap: Label::new(nested_mods),
+                    tap: Label::new(compact_label),
                     kind: KeycodeKind::Modifier,
                     ..Default::default()
                 });

--- a/src/qmk_keycode_labels/advanced.rs
+++ b/src/qmk_keycode_labels/advanced.rs
@@ -2,6 +2,20 @@ use crate::layout_key::{KeycodeKind, Label, LayoutKey};
 use crate::qmk_keycode_labels::basic::get_basic_layout_key;
 use crate::qmk_keycode_labels::constants::*;
 
+fn modifier_symbol(modifier: u16) -> Option<&'static str> {
+    if modifier == QK_LCTL || modifier == QK_RCTL {
+        Some("\u{2388}")
+    } else if modifier == QK_LSFT || modifier == QK_RSFT {
+        Some(egui_phosphor::regular::ARROW_FAT_UP)
+    } else if modifier == QK_LALT || modifier == QK_RALT {
+        Some(egui_phosphor::regular::OPTION)
+    } else if modifier == QK_LGUI || modifier == QK_RGUI {
+        Some(egui_phosphor::fill::DIAMOND)
+    } else {
+        None
+    }
+}
+
 pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
     match keycode_bytes {
         input_bytes if QK_MODS.contains(&input_bytes) => {
@@ -11,7 +25,10 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
 
             let input_modifiers = input_bytes & 0x1f00;
 
-            // For pure shift modifiers, try to show the shifted character directly
+            // `keycode_str` is encoded as "shifted\nunshifted" for shifted keys,
+            // so for pure shift modifiers we use the portion before the first '\n'.
+            // This selects the shifted label for the resulting LayoutKey tap text,
+            // while preserving the original tap_key layout and other fields.
             if input_modifiers == QK_LSFT || input_modifiers == QK_RSFT {
                 if let Some(pos) = keycode_str.find('\n') {
                     return Some(LayoutKey {
@@ -26,17 +43,9 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
                 .iter()
                 .find(|(_, v)| *v == input_modifiers)
             {
-                let mut display_name = name.to_string();
-                // Use our new symbols if it's a simple modifier
-                if input_modifiers == QK_LCTL || input_modifiers == QK_RCTL {
-                    display_name = "\u{2388}".to_string();
-                } else if input_modifiers == QK_LALT || input_modifiers == QK_RALT {
-                    display_name = egui_phosphor::regular::OPTION.to_string();
-                } else if input_modifiers == QK_LGUI || input_modifiers == QK_RGUI {
-                    display_name = egui_phosphor::fill::DIAMOND.to_string();
-                } else if input_modifiers == QK_LSFT || input_modifiers == QK_RSFT {
-                    display_name = egui_phosphor::regular::ARROW_FAT_UP.to_string();
-                }
+                let display_name = modifier_symbol(input_modifiers)
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| name.to_string());
 
                 return Some(LayoutKey {
                     tap: Label::new(format!("{}{}", display_name, keycode_str)),
@@ -71,15 +80,19 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
                 let mut compact_label = String::new();
                 for part in enabled.iter() {
                     let sym = match *part {
-                        "LCTL" | "RCTL" | "C" => "\u{2388}",
-                        "LSFT" | "RSFT" | "S" => egui_phosphor::regular::ARROW_FAT_UP,
-                        "LALT" | "RALT" | "A" | "ALGR" => egui_phosphor::regular::OPTION,
+                        "LCTL" | "RCTL" | "C" => modifier_symbol(QK_LCTL),
+                        "LSFT" | "RSFT" | "S" => modifier_symbol(QK_LSFT),
+                        "LALT" | "RALT" | "A" | "ALGR" => modifier_symbol(QK_LALT),
                         "LGUI" | "RGUI" | "G" | "LCMD" | "LWIN" | "RCMD" | "RWIN" => {
-                            egui_phosphor::fill::DIAMOND
+                            modifier_symbol(QK_LGUI)
                         }
-                        _ => *part,
+                        _ => None,
                     };
-                    compact_label.push_str(sym);
+                    if let Some(sym) = sym {
+                        compact_label.push_str(sym);
+                    } else {
+                        compact_label.push_str(*part);
+                    }
                 }
                 compact_label.push_str(&keycode_str);
 
@@ -167,24 +180,29 @@ fn mod_value_to_string(mod_mask: u16) -> String {
     // Since we use the same symbols for Left and Right, we only need to check bits 0-3.
 
     if mod_mask & MOD_LCTL != 0 {
-        mods.push("\u{2388}");
+        if let Some(sym) = modifier_symbol(QK_LCTL) {
+            mods.push(sym);
+        }
     }
     if mod_mask & MOD_LSFT != 0 {
-        mods.push(egui_phosphor::regular::ARROW_FAT_UP);
+        if let Some(sym) = modifier_symbol(QK_LSFT) {
+            mods.push(sym);
+        }
     }
     if mod_mask & MOD_LALT != 0 {
-        mods.push(egui_phosphor::regular::OPTION);
+        if let Some(sym) = modifier_symbol(QK_LALT) {
+            mods.push(sym);
+        }
     }
     if mod_mask & MOD_LGUI != 0 {
-        mods.push(egui_phosphor::fill::DIAMOND);
+        if let Some(sym) = modifier_symbol(QK_LGUI) {
+            mods.push(sym);
+        }
     }
 
     if mods.is_empty() {
         "None".to_string()
     } else {
-        mods.into_iter()
-            .map(|s| s.to_string())
-            .collect::<Vec<_>>()
-            .join("")
+        mods.join("")
     }
 }

--- a/src/qmk_keycode_labels/basic.rs
+++ b/src/qmk_keycode_labels/basic.rs
@@ -834,6 +834,9 @@ pub fn get_basic_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
             )),
             ..Default::default()
         }),
+        // Mouse buttons 1–3 use icon symbols for the common left/right/middle buttons,
+        // while buttons 4–8 fall back to text labels because standard auxiliary mouse button
+        // icons are not available/standardized.
         Keycode::QK_MOUSE_BUTTON_1 => Some(LayoutKey {
             tap: Label::new(""),
             symbol: Some(egui_phosphor::regular::MOUSE_LEFT_CLICK.to_string()),

--- a/src/qmk_keycode_labels/basic.rs
+++ b/src/qmk_keycode_labels/basic.rs
@@ -799,19 +799,39 @@ pub fn get_basic_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
             ..Default::default()
         }),
         Keycode::QK_MOUSE_CURSOR_UP => Some(LayoutKey {
-            tap: Label::new("Mouse ↑"),
+            tap: Label::new(""),
+            symbol: Some(format!(
+                "{}\n{}",
+                egui_phosphor::regular::ARROW_UP,
+                egui_phosphor::regular::MOUSE_SIMPLE
+            )),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_CURSOR_DOWN => Some(LayoutKey {
-            tap: Label::new("Mouse ↓"),
+            tap: Label::new(""),
+            symbol: Some(format!(
+                "{}\n{}",
+                egui_phosphor::regular::MOUSE_SIMPLE,
+                egui_phosphor::regular::ARROW_DOWN
+            )),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_CURSOR_LEFT => Some(LayoutKey {
-            tap: Label::new("Mouse ←"),
+            tap: Label::new(""),
+            symbol: Some(format!(
+                "{} {}",
+                egui_phosphor::regular::ARROW_LEFT,
+                egui_phosphor::regular::MOUSE_SIMPLE
+            )),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_CURSOR_RIGHT => Some(LayoutKey {
-            tap: Label::new("Mouse →"),
+            tap: Label::new(""),
+            symbol: Some(format!(
+                "{} {}",
+                egui_phosphor::regular::MOUSE_SIMPLE,
+                egui_phosphor::regular::ARROW_RIGHT
+            )),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_BUTTON_1 => Some(LayoutKey {
@@ -847,19 +867,39 @@ pub fn get_basic_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
             ..Default::default()
         }),
         Keycode::QK_MOUSE_WHEEL_UP => Some(LayoutKey {
-            tap: Label::new("Mouse Wh ↑"),
+            tap: Label::new(""),
+            symbol: Some(format!(
+                "{}\n{}",
+                egui_phosphor::regular::ARROW_UP,
+                egui_phosphor::regular::MOUSE_SCROLL
+            )),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_WHEEL_DOWN => Some(LayoutKey {
-            tap: Label::new("Mouse Wh ↓"),
+            tap: Label::new(""),
+            symbol: Some(format!(
+                "{}\n{}",
+                egui_phosphor::regular::MOUSE_SCROLL,
+                egui_phosphor::regular::ARROW_DOWN
+            )),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_WHEEL_LEFT => Some(LayoutKey {
-            tap: Label::new("Mouse Wh ←"),
+            tap: Label::new(""),
+            symbol: Some(format!(
+                "{} {}",
+                egui_phosphor::regular::ARROW_LEFT,
+                egui_phosphor::regular::MOUSE_SCROLL
+            )),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_WHEEL_RIGHT => Some(LayoutKey {
-            tap: Label::new("Mouse Wh →"),
+            tap: Label::new(""),
+            symbol: Some(format!(
+                "{} {}",
+                egui_phosphor::regular::MOUSE_SCROLL,
+                egui_phosphor::regular::ARROW_RIGHT
+            )),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_ACCELERATION_0 => Some(LayoutKey {

--- a/src/qmk_keycode_labels/basic.rs
+++ b/src/qmk_keycode_labels/basic.rs
@@ -875,46 +875,50 @@ pub fn get_basic_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
             ..Default::default()
         }),
         Keycode::KC_LEFT_CTRL => Some(LayoutKey {
-            tap: Label::new("Ctrl"),
+            tap: Label::new(""),
+            symbol: Some("\u{2388}".to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::KC_LEFT_SHIFT => Some(LayoutKey {
-            tap: Label::new("Shift"),
+            tap: Label::new(""),
             symbol: Some(egui_phosphor::regular::ARROW_FAT_UP.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::KC_LEFT_ALT => Some(LayoutKey {
-            tap: Label::new("Alt"),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::regular::OPTION.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::KC_LEFT_GUI => Some(LayoutKey {
-            tap: Label::new("Win"),
-            symbol: Some(egui_phosphor::regular::WINDOWS_LOGO.to_string()),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::fill::DIAMOND.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::KC_RIGHT_CTRL => Some(LayoutKey {
-            tap: Label::new("Ctrl"),
+            tap: Label::new(""),
+            symbol: Some("\u{2388}".to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::KC_RIGHT_SHIFT => Some(LayoutKey {
-            tap: Label::new("Shift"),
+            tap: Label::new(""),
             symbol: Some(egui_phosphor::regular::ARROW_FAT_UP.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::KC_RIGHT_ALT => Some(LayoutKey {
-            tap: Label::new("Alt"),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::regular::OPTION.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::KC_RIGHT_GUI => Some(LayoutKey {
-            tap: Label::new("Win"),
-            symbol: Some(egui_phosphor::regular::WINDOWS_LOGO.to_string()),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::fill::DIAMOND.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),

--- a/src/qmk_keycode_labels/basic.rs
+++ b/src/qmk_keycode_labels/basic.rs
@@ -835,15 +835,18 @@ pub fn get_basic_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
             ..Default::default()
         }),
         Keycode::QK_MOUSE_BUTTON_1 => Some(LayoutKey {
-            tap: Label::new("Mouse Btn1"),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::regular::MOUSE_LEFT_CLICK.to_string()),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_BUTTON_2 => Some(LayoutKey {
-            tap: Label::new("Mouse Btn2"),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::regular::MOUSE_RIGHT_CLICK.to_string()),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_BUTTON_3 => Some(LayoutKey {
-            tap: Label::new("Mouse Btn3"),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::regular::MOUSE_MIDDLE_CLICK.to_string()),
             ..Default::default()
         }),
         Keycode::QK_MOUSE_BUTTON_4 => Some(LayoutKey {

--- a/src/qmk_keycode_labels/constants.rs
+++ b/src/qmk_keycode_labels/constants.rs
@@ -12,6 +12,7 @@ pub const QK_TOGGLE_LAYER: Range<u16> = 0x5260..0x5280;
 pub const QK_ONE_SHOT_LAYER: Range<u16> = 0x5280..0x52A0;
 pub const QK_ONE_SHOT_MOD: Range<u16> = 0x52a0..0x52c0;
 pub const QK_LAYER_TAP_TOGGLE: Range<u16> = 0x52C0..0x52E0;
+pub const QK_TAP_DANCE: Range<u16> = 0x5700..0x5720;
 pub const QK_MACRO: Range<u16> = 0x7700..0x7780;
 pub const QK_KB: Range<u16> = 0x7E00..0x7F00;
 
@@ -29,10 +30,6 @@ pub const MOD_LCTL: u16 = 0x01;
 pub const MOD_LSFT: u16 = 0x02;
 pub const MOD_LALT: u16 = 0x04;
 pub const MOD_LGUI: u16 = 0x08;
-pub const MOD_RCTL: u16 = 0x10;
-pub const MOD_RSFT: u16 = 0x20;
-pub const MOD_RALT: u16 = 0x40;
-pub const MOD_RGUI: u16 = 0x80;
 
 pub const MODIFIER_KEY_TO_VALUE: &[(&str, u16)] = &[
     ("LCTL", QK_LCTL),

--- a/src/qmk_keycode_labels/layer.rs
+++ b/src/qmk_keycode_labels/layer.rs
@@ -55,13 +55,16 @@ mod tests {
 
     #[test]
     fn test_get_layer_layout_key_tap_dance() {
-        let key = get_layer_layout_key(0x5700).unwrap();
+        let key = get_layer_layout_key(QK_TAP_DANCE.start).unwrap();
         assert_eq!(key.tap.full, "TD(0)");
+        assert!(key.layer_ref.is_none());
 
-        let key = get_layer_layout_key(0x570A).unwrap();
+        let key = get_layer_layout_key(QK_TAP_DANCE.start + 0xA).unwrap();
         assert_eq!(key.tap.full, "TD(10)");
+        assert!(key.layer_ref.is_none());
 
-        let key = get_layer_layout_key(0x571F).unwrap();
+        let key = get_layer_layout_key(QK_TAP_DANCE.start + 0x1F).unwrap();
         assert_eq!(key.tap.full, "TD(31)");
+        assert!(key.layer_ref.is_none());
     }
 }

--- a/src/qmk_keycode_labels/layer.rs
+++ b/src/qmk_keycode_labels/layer.rs
@@ -23,6 +23,10 @@ pub fn get_layer_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
             let l = (b - QK_LAYER_TAP_TOGGLE.start) as u8;
             (format!("TT({})", l), Some(l))
         }
+        b if QK_TAP_DANCE.contains(&b) => {
+            let n = b - QK_TAP_DANCE.start;
+            (format!("TD({})", n), None)
+        }
         b if QK_DEF_LAYER.contains(&b) => {
             let l = (b - QK_DEF_LAYER.start) as u8;
             (format!("DF({})", l), None)
@@ -43,4 +47,21 @@ pub fn get_layer_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
         layer_ref,
         ..Default::default()
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_layer_layout_key_tap_dance() {
+        let key = get_layer_layout_key(0x5700).unwrap();
+        assert_eq!(key.tap.full, "TD(0)");
+
+        let key = get_layer_layout_key(0x570A).unwrap();
+        assert_eq!(key.tap.full, "TD(10)");
+
+        let key = get_layer_layout_key(0x571F).unwrap();
+        assert_eq!(key.tap.full, "TD(31)");
+    }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,3 +1,4 @@
+use crate::protocols::ConnectionSpec;
 use ini::Ini;
 use std::fmt;
 use std::fs;
@@ -172,6 +173,8 @@ pub struct Settings {
     pub timeout: i64,
     pub margin: u32,
     pub theme: ThemeSettings,
+    pub show_on_layer_change: bool,
+    pub last_connection: Option<ConnectionSpec>,
 }
 
 impl Default for Settings {
@@ -184,6 +187,8 @@ impl Default for Settings {
             timeout: 2000,
             margin: 10,
             theme: ThemeSettings::default(),
+            show_on_layer_change: true,
+            last_connection: None,
         }
     }
 }
@@ -239,6 +244,15 @@ impl Settings {
         section.set("position", self.position.to_string());
         section.set("timeout", self.timeout.to_string());
         section.set("margin", self.margin.to_string());
+        section.set(
+            "show_on_layer_change",
+            self.show_on_layer_change.to_string(),
+        );
+        if let Some(conn) = &self.last_connection {
+            if let Ok(json) = serde_json::to_string(conn) {
+                section.set("last_connection", json);
+            }
+        }
         for (index, color) in self.theme.layer_colors.iter().enumerate() {
             section.set(format!("layer_color_{index}"), color.to_string());
         }
@@ -275,6 +289,12 @@ impl Settings {
         }
         if let Some(val) = section.get("margin") {
             s.margin = val.parse().unwrap_or(s.margin);
+        }
+        if let Some(val) = section.get("show_on_layer_change") {
+            s.show_on_layer_change = val.parse().unwrap_or(s.show_on_layer_change);
+        }
+        if let Some(val) = section.get("last_connection") {
+            s.last_connection = serde_json::from_str(val).ok();
         }
         for index in 0..s.theme.layer_colors.len() {
             if let Some(val) = section.get(&format!("layer_color_{index}")) {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -252,6 +252,9 @@ impl Settings {
             if let Ok(json) = serde_json::to_string(conn) {
                 section.set("last_connection", json);
             }
+        } else {
+            let key = String::from("last_connection");
+            section.delete(&key);
         }
         for (index, color) in self.theme.layer_colors.iter().enumerate() {
             section.set(format!("layer_color_{index}"), color.to_string());
@@ -293,7 +296,10 @@ impl Settings {
         if let Some(val) = section.get("show_on_layer_change") {
             s.show_on_layer_change = val.parse().unwrap_or(s.show_on_layer_change);
         }
-        if let Some(val) = section.get("last_connection") {
+        if let Some(val) = section
+            .get("last_connection")
+            .filter(|val| !val.trim().is_empty())
+        {
             s.last_connection = serde_json::from_str(val).ok();
         }
         for index in 0..s.theme.layer_colors.len() {

--- a/src/zmk_keycode_labels/behavior.rs
+++ b/src/zmk_keycode_labels/behavior.rs
@@ -37,9 +37,14 @@ pub fn behavior_to_layout_key(behavior: &Behavior) -> Option<LayoutKey> {
         Behavior::ModTap { hold, tap } => {
             let hold_key = hid_usage_to_layout_key(*hold);
             let tap_key = hid_usage_to_layout_key(*tap);
+            let hold_label = if let Some(symbol) = hold_key.symbol {
+                Label::new(symbol)
+            } else {
+                hold_key.tap
+            };
             Some(LayoutKey {
                 tap: tap_key.tap,
-                hold: Some(hold_key.tap),
+                hold: Some(hold_label),
                 symbol: tap_key.symbol,
                 kind: KeycodeKind::Modifier,
                 layer_ref: None,

--- a/src/zmk_keycode_labels/hid_usage.rs
+++ b/src/zmk_keycode_labels/hid_usage.rs
@@ -4,7 +4,8 @@ use zmk_studio_api::HidUsage;
 use super::keycode_label::keycode_to_layout_key;
 
 pub fn hid_usage_to_layout_key(usage: HidUsage) -> LayoutKey {
-    if usage.modifiers() == 0 {
+    let mods = usage.modifiers();
+    if mods == 0 {
         if let Some(keycode) = usage.known_keycode() {
             return keycode_to_layout_key(&keycode);
         }
@@ -20,15 +21,33 @@ pub fn hid_usage_to_layout_key(usage: HidUsage) -> LayoutKey {
     }
 
     let base = usage.base();
-    let base_label = if let Some(base_keycode) = base.known_keycode() {
-        keycode_to_layout_key(&base_keycode).tap.full
+    let mut base_key = if let Some(base_keycode) = base.known_keycode() {
+        keycode_to_layout_key(&base_keycode)
     } else {
-        format!("0x{:08X}", base.to_hid_usage())
+        LayoutKey {
+            tap: Label::new(format!("0x{:08X}", base.to_hid_usage())),
+            ..Default::default()
+        }
     };
 
-    let mut rendered = base_label;
+    // For pure shift modifiers (Left Shift: 0x02, Right Shift: 0x20)
+    if mods == 0x02 || mods == 0x20 {
+        if let Some(pos) = base_key.tap.full.find('\n') {
+            base_key.tap = Label::new(base_key.tap.full[..pos].to_string());
+            return base_key;
+        }
+    }
+
+    let mut rendered = base_key.tap.full;
     for modifier in usage.modifier_labels().iter().rev() {
-        rendered = format!("{modifier}({rendered})");
+        let sym = match modifier.as_ref() {
+            "LC" | "RC" => "\u{2388}",
+            "LS" | "RS" => egui_phosphor::regular::ARROW_FAT_UP,
+            "LA" | "RA" => egui_phosphor::regular::OPTION,
+            "LG" | "RG" => egui_phosphor::fill::DIAMOND,
+            _ => modifier,
+        };
+        rendered = format!("{}{}", sym, rendered);
     }
 
     LayoutKey {

--- a/src/zmk_keycode_labels/keycode_label.rs
+++ b/src/zmk_keycode_labels/keycode_label.rs
@@ -724,25 +724,25 @@ fn keycode_label(keycode: &Keycode) -> Option<LayoutKey> {
             ..Default::default()
         }),
         Keycode::RIGHT_CONTROL => Some(LayoutKey {
-            tap: Label::new(""),
+            tap: Label::default(),
             symbol: Some("\u{2388}".to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::RIGHT_SHIFT => Some(LayoutKey {
-            tap: Label::new(""),
+            tap: Label::default(),
             symbol: Some(egui_phosphor::regular::ARROW_FAT_UP.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::RIGHT_ALT => Some(LayoutKey {
-            tap: Label::new(""),
+            tap: Label::default(),
             symbol: Some(egui_phosphor::regular::OPTION.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::RIGHT_COMMAND => Some(LayoutKey {
-            tap: Label::new(""),
+            tap: Label::default(),
             symbol: Some(egui_phosphor::fill::DIAMOND.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()

--- a/src/zmk_keycode_labels/keycode_label.rs
+++ b/src/zmk_keycode_labels/keycode_label.rs
@@ -700,49 +700,54 @@ fn keycode_label(keycode: &Keycode) -> Option<LayoutKey> {
             ..Default::default()
         }),
         Keycode::LEFT_CONTROL => Some(LayoutKey {
-            tap: Label::new("Ctrl"),
+            tap: Label::new(""),
+            symbol: Some("\u{2388}".to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::LEFT_SHIFT => Some(LayoutKey {
-            tap: Label::new("Shift"),
+            tap: Label::new(""),
             symbol: Some(egui_phosphor::regular::ARROW_FAT_UP.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::LEFT_ALT => Some(LayoutKey {
-            tap: Label::new("Alt"),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::regular::OPTION.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::LEFT_COMMAND => Some(LayoutKey {
-            tap: Label::new("Win"),
-            symbol: Some(egui_phosphor::regular::WINDOWS_LOGO.to_string()),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::fill::DIAMOND.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::RIGHT_CONTROL => Some(LayoutKey {
-            tap: Label::new("Ctrl"),
+            tap: Label::new(""),
+            symbol: Some("\u{2388}".to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::RIGHT_SHIFT => Some(LayoutKey {
-            tap: Label::new("Shift"),
+            tap: Label::new(""),
             symbol: Some(egui_phosphor::regular::ARROW_FAT_UP.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::RIGHT_ALT => Some(LayoutKey {
-            tap: Label::new("Alt"),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::regular::OPTION.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
         Keycode::RIGHT_COMMAND => Some(LayoutKey {
-            tap: Label::new("Win"),
-            symbol: Some(egui_phosphor::regular::WINDOWS_LOGO.to_string()),
+            tap: Label::new(""),
+            symbol: Some(egui_phosphor::fill::DIAMOND.to_string()),
             kind: KeycodeKind::Modifier,
             ..Default::default()
         }),
+
         Keycode::K_PLAY_PAUSE => Some(LayoutKey {
             symbol: Some(egui_phosphor::regular::PLAY_PAUSE.to_string()),
             ..Default::default()


### PR DESCRIPTION
This project is exactly what I have been looking for, and tried to poorly implement with a static keymap image and a file preview tool launched from a keybinding! I made fair number fixes and enhancements to really dial it to my use case, most/all of which I think others could find useful.

I recognize this isn't a great PR, it does a lot of different things, mixing both features and fixes together. I think it could all be merged in, but I also understand there may be some choices that aren't applicable with your vision of the project. So this is more like a menu of things to look at. If you want to cherry pick specific items that is great. If you want to ask me to try extracting out specific things you are interested in as a separate PR, definitely ask.

Also, I'm not a rust programmer. I really endeavored to ensure this isn't AI slop, but most of the credit of the changes goes to Gemini CLI, and I can really only give a quick pass to ensure things don't look ridiculously busted.

## Fixes

* The layout for my split keyboard with rotated thumb keys did not render correctly, so I got it fixed.
* Added the Tap Dance codes
* Fixed some alternate color bleed from the base label (my homerow mods on the base layer caused the alt rendering on the other layers)
* My right modifiers rendered as `MOD_LCTL | MOD_RCTL` and `MOD_LSFT | MOD_RCTL`, and so on. As I switched to symbols, no distinction was needed anyway, so I just dropped that and displayed just the single modifier.
* Fix highlighting on short duration keys. On my tap-hold keys, the "tap" action was apparently sent to the computer with an extremely short duration, so the highlight is often missed. Implemented a min hold so that the key will always light up. I never saw this issue on typical keys

## Features

* Changed all modifiers (gui, alt, control, shift) to use symbols, and switched Gui to the diamond used in the ergomech circles and drop the Windows logo
* Rendered Tap Hold keys with the hold key at the bottom of the key with a darkened background
* Changed the rendering of shifted keys, to just show the shifted key (`*` instead of `LSFT(* 8)`)
* Changed some of the mouse buttons to icons: left, middle, right click, movement direction, scroll direction
* Added an option to autoconnect to the last connected keyboard on startup 
* Added cli option for `--toggle` that would message the running process to show or high the keys
* Added a configuration option to disable the automatic display on layer change
* Added cli option for `--settings` to redisplay the settings when autoconnect is on

The idea for the last set of changes is to enable binding the display to a keyboard shortcut for on demand display and hiding. I mostly don't want it to show up, even on layer channels, but want it easily available for a reference.

## Testing

I only have one keyboard, running Vial. I tried to ensure the changes were compatible with ZMK and QMK, but I don't have those to actually test with.

Currently, I've only tested everything on Linux. I will move it to my work laptop which is MacOS soon, but it will be a bit before I could try it on Windows.

## Details

Here are some screenshot details so demonstrate what I described above.

### Layout fix

For the layout fix, I did want to show a before an after. This is the before

<img width="1775" height="694" alt="Screenshot From 2026-05-05 18-51-22" src="https://github.com/user-attachments/assets/a4416a1f-179e-43c7-ae27-ce83624e6511" />

And then after:

<img width="1775" height="694" alt="Screenshot From 2026-05-04 21-35-29" src="https://github.com/user-attachments/assets/d355073e-f68f-4cf1-a0ec-ce4c7981646a" />

### Modifier symbols and tap-hold rendering

<img width="1780" height="691" alt="Screenshot-1" src="https://github.com/user-attachments/assets/2bdec807-9967-4bb4-8c35-71ad7b931bfb" />


### The mouse symbols

<img width="1749" height="669" alt="Screenshot-2" src="https://github.com/user-attachments/assets/82c7312b-f9ab-418f-ad5d-a5e8aab7b669" />

