### PR TITLE
Support Vial layout options and avoid ZMK misclassification

### DIFF
--- a/src/device_discovery.rs
+++ b/src/device_discovery.rs
@@ -84,6 +84,7 @@ pub fn discover_devices() -> Vec<DiscoveredDevice> {
 
     let mut devices: Vec<DiscoveredDevice> = Vec::new();
     let mut zmk_vid_pid: HashSet<(u16, u16)> = HashSet::new();
+    let mut non_zmk_via_vid_pid: HashSet<(u16, u16)> = HashSet::new();
 
     {
         let mut seen_via: HashSet<(u16, u16)> = HashSet::new();
@@ -115,11 +116,17 @@ pub fn discover_devices() -> Vec<DiscoveredDevice> {
             });
             if kind == DeviceKind::Zmk {
                 zmk_vid_pid.insert((dev.vendor_id, dev.product_id));
+            } else {
+                non_zmk_via_vid_pid.insert((dev.vendor_id, dev.product_id));
             }
         }
     }
 
     for sp in zmk_rpc::scan_serial_ports() {
+        if non_zmk_via_vid_pid.contains(&(sp.vid, sp.pid)) {
+            continue;
+        }
+
         // Prefer the product name from HID if the keyboard is also visible there.
         let base_name = all_hid
             .iter()
@@ -141,6 +148,10 @@ pub fn discover_devices() -> Vec<DiscoveredDevice> {
     if let Ok(ble_devices) = zmk_rpc::scan_ble_devices() {
         for ble in ble_devices {
             if let Some(hid) = find_matching_hid_for_ble(&all_hid, &ble.display_name) {
+                if non_zmk_via_vid_pid.contains(&(hid.vendor_id, hid.product_id)) {
+                    continue;
+                }
+
                 // If a serial transport exists for the same board, prefer serial and hide BLE.
                 // This avoids platform-specific BLE RPC instability when USB and BLE are both active.
                 if zmk_vid_pid.contains(&(hid.vendor_id, hid.product_id)) {


### PR DESCRIPTION
## Checklist

- [ x ] I have read the [contribution guidelines](https://github.com/srwi/keypeek/blob/master/CONTRIBUTING.md)

## Summary

This PR improves Vial support and fixes device discovery for Vial/QMK keyboards.

## Related issue

Svalboard is a QMK keyboard. The device was incorrectly identified as a ZMK device. It would not connect because of this. 

<img width="338" height="120" alt="screenshot-2026-07-28_20-03-15" src="https://github.com/user-attachments/assets/bfb415c3-6422-4a91-a4ec-0e7ac692a21b" />


## Type of change

- [ x ] Bug fix
- [ x ] New feature

- Prevent Vial/QMK devices from being replaced by a guessed ZMK serial/BLE device when they share the same VID/PID.
- Add parsing of Vial `layouts.labels`.
- Filter optional Vial/KLE keys using the existing Layout dropdown.
- Add a unit test covering Vial layout-option filtering.

With the help of AI I was able to identify it was getting misclassified. I'm not well versed in Rust. The changes in device_discovery.rs are related to the misclassification. 

The other changes are less important but would be more of an annoyance for users. The Svalboard has integrated pointer devices; using a pointer activate a layer so it flashes the secondary south keys. This is mostly due to them defaulting to a key rather than a pass-through in Vial. Binding them as a pass-through or using the Sval board without them bound works. Its just anoying.  SvalBoard has options to have a secondary set of south keys. More users don't have them, as it's an experimental option. This was added/changed to remove the secondary keys in the setup. 
<img width="656" height="660" alt="image" src="https://github.com/user-attachments/assets/69524a96-1ad2-49be-9e1f-ba0ebcf85cce" />


## Testing

 - `cargo fmt`
- `cargo test vial_layout_options_filter_optional_keys`
- `cargo build`
- 
## Screenshots or recordings

<img width="1855" height="1122" alt="screenshot-2026-07-28_20-46-42" src="https://github.com/user-attachments/assets/a339c9e4-f437-4a11-a6e3-54fcf5719b40" />
<img width="472" height="566" alt="screenshot-2026-07-28_20-46-31" src="https://github.com/user-attachments/assets/4e761e15-df8c-43b3-84fc-d977006644ff" />
<img width="1750" height="659" alt="screenshot-2026-07-28_20-46-13" src="https://github.com/user-attachments/assets/8e38c181-c90a-40ee-a8ad-c1fa6c2b3843" />

Glad I found this; I was about to write something like this myself. Although it would have been in some variant of C