### PR TITLE
Resolve keycap labels against the OS's live active keyboard layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,6 +2576,7 @@ dependencies = [
  "winit",
  "winreg",
  "winresource",
+ "xkbcommon 0.9.0",
  "zmk-studio-api",
 ]
 
@@ -4813,7 +4814,7 @@ dependencies = [
  "wayland-protocols-misc",
  "wayland-protocols-wlr",
  "wayland-scanner",
- "xkbcommon",
+ "xkbcommon 0.8.0",
  "xkeysym",
 ]
 
@@ -6619,6 +6620,17 @@ name = "xkbcommon"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9"
+dependencies = [
+ "libc",
+ "memmap2",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkbcommon"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a974f48060a14e95705c01f24ad9c3345022f4d97441b8a36beb7ed5c4a02d"
 dependencies = [
  "libc",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ zmk-studio-api = { version = "0.5.1", features = ["serial", "ble"] }
 gtk = "0.18"
 winit = { version = "0.30.13", features = ["x11"] }
 egui_glow = "0.34.3"
+xkbcommon = "0.9"
 smithay-client-toolkit = "0.20.0"
 wayland-client = "0.31.14"
 wayland-egl = "0.32.11"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod device_discovery;
 mod key_matrix;
 mod keyboard;
 mod layout_key;
+mod os_layout;
 mod overlay_window;
 mod platform;
 mod protocols;

--- a/src/os_layout.rs
+++ b/src/os_layout.rs
@@ -1,0 +1,43 @@
+//! Resolves the character the OS's *active* keyboard layout produces for a
+//! given key, instead of guessing from a static per-language table.
+//!
+//! Both QMK's `Keycode` and ZMK's `HidUsage` are numerically USB HID
+//! Keyboard/Keypad-page usage IDs, so this module only needs that one
+//! number — it doesn't know or care which protocol the keyboard speaks.
+//!
+//! Linux/Wayland only for now (other platforms return `None`, so callers
+//! fall back to their existing static table). Windows/macOS/X11 are
+//! comparable-effort follow-ups; add them as sibling `#[cfg(target_os =
+//! "...")]` modules here without touching this one.
+
+#[derive(Clone, Copy)]
+pub enum Modifier {
+    /// No modifier held — the plain/base character.
+    Base,
+    Shift,
+    AltGr,
+}
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+#[cfg(target_os = "linux")]
+pub fn resolve(hid_usage: u16, modifier: Modifier) -> Option<String> {
+    linux::resolve(hid_usage, modifier)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn resolve(_hid_usage: u16, _modifier: Modifier) -> Option<String> {
+    None
+}
+
+/// Convenience for the `shifted` legend field.
+pub fn shifted_char(hid_usage: u16) -> Option<String> {
+    resolve(hid_usage, Modifier::Shift)
+}
+
+/// Convenience for the `tap` label on keys with no sensible US-layout
+/// placeholder to fall back to (ISO-only keys like NUBS/NUHS).
+pub fn base_char(hid_usage: u16) -> Option<String> {
+    resolve(hid_usage, Modifier::Base)
+}

--- a/src/os_layout/linux.rs
+++ b/src/os_layout/linux.rs
@@ -1,0 +1,221 @@
+//! Linux backend: reads the compositor's live XKB keymap over Wayland and
+//! translates a USB HID usage ID through it. Deliberately never creates a
+//! `wl_surface` — this client can never be given keyboard focus, which is
+//! correct for an always-on-top overlay that must not steal input from
+//! whatever the user is actually typing into. Core `wl_keyboard` protocol
+//! delivers the active keymap regardless of focus (verified in practice).
+//!
+//! X11 isn't covered here (Wayland only) and falls back to `None` like
+//! every other unsupported case.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use wayland_client::{
+    protocol::{wl_keyboard, wl_registry, wl_seat},
+    Connection, Dispatch, QueueHandle,
+};
+use xkbcommon::xkb;
+
+use super::Modifier;
+
+struct State {
+    xkb_context: xkb::Context,
+    // Holds the keymap's *text* form, not an `xkb::State`/`xkb::Keymap` —
+    // those wrap a raw C pointer that isn't `Send`, so each `resolve()`
+    // call parses its own throwaway `State` from this string instead of
+    // sharing one across the thread boundary.
+    shared: Arc<Mutex<Option<String>>>,
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for State {
+    fn event(
+        _: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name, interface, ..
+        } = event
+        {
+            if interface == "wl_seat" {
+                let seat = registry.bind::<wl_seat::WlSeat, _, _>(name, 7, qh, ());
+                let _keyboard = seat.get_keyboard(qh, ());
+            }
+        }
+    }
+}
+
+impl Dispatch<wl_seat::WlSeat, ()> for State {
+    fn event(_: &mut Self, _: &wl_seat::WlSeat, _: wl_seat::Event, _: &(), _: &Connection, _: &QueueHandle<Self>) {}
+}
+
+impl Dispatch<wl_keyboard::WlKeyboard, ()> for State {
+    fn event(
+        state: &mut Self,
+        _: &wl_keyboard::WlKeyboard,
+        event: wl_keyboard::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        // The compositor resends this if the user switches layout at
+        // runtime, so `shared` always reflects the currently active one.
+        if let wl_keyboard::Event::Keymap { fd, size, .. } = event {
+            let parsed = unsafe {
+                xkb::Keymap::new_from_fd(
+                    &state.xkb_context,
+                    fd,
+                    size as usize,
+                    xkb::KEYMAP_FORMAT_TEXT_V1,
+                    xkb::KEYMAP_COMPILE_NO_FLAGS,
+                )
+            };
+            if let Ok(Some(keymap)) = parsed {
+                let text = keymap.get_as_string(xkb::KEYMAP_FORMAT_TEXT_V1);
+                *state.shared.lock().unwrap() = Some(text);
+            }
+        }
+    }
+}
+
+/// USB HID Keyboard/Keypad usage ID -> Linux evdev keycode. Verbatim from
+/// the kernel's own `hid_keyboard[256]` table (`drivers/hid/hid-input.c`),
+/// not hand-guessed — 0 marks entries the kernel itself leaves unmapped.
+#[rustfmt::skip]
+const HID_TO_EVDEV: [u8; 256] = [
+      0,  0,  0,  0, 30, 48, 46, 32, 18, 33, 34, 35, 23, 36, 37, 38,
+     50, 49, 24, 25, 16, 19, 31, 20, 22, 47, 17, 45, 21, 44,  2,  3,
+      4,  5,  6,  7,  8,  9, 10, 11, 28,  1, 14, 15, 57, 12, 13, 26,
+     27, 43, 43, 39, 40, 41, 51, 52, 53, 58, 59, 60, 61, 62, 63, 64,
+     65, 66, 67, 68, 87, 88, 99, 70,119,110,102,104,111,107,109,106,
+    105,108,103, 69, 98, 55, 74, 78, 96, 79, 80, 81, 75, 76, 77, 71,
+     72, 73, 82, 83, 86,127,116,117,183,184,185,186,187,188,189,190,
+    191,192,193,194,134,138,130,132,128,129,131,137,133,135,136,113,
+    115,114,  0,  0,  0,121,  0, 89, 93,124, 92, 94, 95,  0,  0,  0,
+    122,123, 90, 91, 85,  0,  0,  0,  0,  0,  0,  0,111,  0,  0,  0,
+      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+      0,  0,  0,  0,  0,  0,179,180,  0,  0,  0,  0,  0,  0,  0,  0,
+      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+      0,  0,  0,  0,  0,  0,  0,  0,111,  0,  0,  0,  0,  0,  0,  0,
+     29, 42, 56,125, 97, 54,100,126,164,166,165,163,161,115,114,113,
+    150,158,159,128,136,177,178,176,142,152,173,140,  0,  0,  0,  0,
+];
+
+fn shared_state() -> &'static Arc<Mutex<Option<String>>> {
+    static SHARED: OnceLock<Arc<Mutex<Option<String>>>> = OnceLock::new();
+    SHARED.get_or_init(|| {
+        let shared = Arc::new(Mutex::new(None));
+        let for_thread = Arc::clone(&shared);
+        std::thread::Builder::new()
+            .name("os-layout-wayland".into())
+            .spawn(move || run(for_thread))
+            .ok();
+        shared
+    })
+}
+
+fn run(shared: Arc<Mutex<Option<String>>>) {
+    let Ok(conn) = Connection::connect_to_env() else {
+        return; // Not on Wayland (e.g. X11 session) — resolve() stays None.
+    };
+    let mut event_queue = conn.new_event_queue();
+    let qh = event_queue.handle();
+    let _registry = conn.display().get_registry(&qh, ());
+    let mut state = State {
+        xkb_context: xkb::Context::new(xkb::CONTEXT_NO_FLAGS),
+        shared,
+    };
+    loop {
+        if event_queue.blocking_dispatch(&mut state).is_err() {
+            return;
+        }
+    }
+}
+
+/// Key labels get resolved once per connect, not every frame, so losing the
+/// startup race against this module's own connect-handshake would stick for
+/// the whole session rather than just one glance. Bounded wait, not a real
+/// stall: the connect is normally done in well under this on a live
+/// compositor; if it's never coming (no Wayland at all) every caller pays
+/// this once, then the shared state answers instantly from then on.
+fn wait_for_keymap_text() -> Option<String> {
+    let shared = shared_state();
+    for _ in 0..20 {
+        if let Some(text) = shared.lock().unwrap().clone() {
+            return Some(text);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    None
+}
+
+pub fn resolve(hid_usage: u16, modifier: Modifier) -> Option<String> {
+    let evdev = *HID_TO_EVDEV.get(usize::from(hid_usage))?;
+    if evdev == 0 {
+        return None;
+    }
+    let keycode = xkb::Keycode::new(u32::from(evdev) + 8);
+
+    let keymap_text = wait_for_keymap_text()?;
+    let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+    let keymap = xkb::Keymap::new_from_string(
+        &context,
+        keymap_text,
+        xkb::KEYMAP_FORMAT_TEXT_V1,
+        xkb::KEYMAP_COMPILE_NO_FLAGS,
+    )?;
+
+    let mut probe = xkb::State::new(&keymap);
+    if let Modifier::Shift | Modifier::AltGr = modifier {
+        let mod_name = match modifier {
+            Modifier::Shift => xkb::MOD_NAME_SHIFT,
+            // "Mod5" is what AltGr is bound to on virtually every layout
+            // that has one; ISO_Level3_Shift/"AltGr" are the same virtual
+            // modifier under different names depending on the keymap's
+            // rules.
+            Modifier::AltGr => "Mod5",
+            Modifier::Base => unreachable!(),
+        };
+        let idx = keymap.mod_get_index(mod_name);
+        if idx == xkb::MOD_INVALID {
+            return None;
+        }
+        probe.update_mask(1 << idx, 0, 0, 0, 0, 0);
+    }
+    let text = probe.key_get_utf8(keycode);
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve, HID_TO_EVDEV};
+    use crate::os_layout::Modifier;
+
+    // Guards against a transcription typo in the table — checked against
+    // known-good Linux evdev keycodes (KEY_A=30, KEY_Q=16, KEY_1=2,
+    // KEY_MINUS=12), not just "does it compile".
+    #[test]
+    fn hid_to_evdev_known_values() {
+        assert_eq!(HID_TO_EVDEV[0x04], 30); // KEY_A
+        assert_eq!(HID_TO_EVDEV[0x14], 16); // KEY_Q
+        assert_eq!(HID_TO_EVDEV[0x1E], 2); // KEY_1
+        assert_eq!(HID_TO_EVDEV[0x2D], 12); // KEY_MINUS
+    }
+
+    // Needs a real Wayland session with a non-US layout active, so it's not
+    // part of the normal `cargo test` run — `cargo test -- --ignored` on a
+    // machine set to German confirms the live path end to end.
+    #[test]
+    #[ignore]
+    fn live_german_shift_matches_actual_layout() {
+        assert_eq!(resolve(0x1F, Modifier::Shift).as_deref(), Some("\"")); // KC_2
+        assert_eq!(resolve(0x24, Modifier::Shift).as_deref(), Some("/")); // KC_7
+    }
+}

--- a/src/qmk_keycode_labels/advanced.rs
+++ b/src/qmk_keycode_labels/advanced.rs
@@ -7,30 +7,38 @@ pub fn get_advanced_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
     match keycode_bytes {
         input_bytes if QK_MODS.contains(&input_bytes) => {
             let keycode = input_bytes & 0xff;
-            let inner_key = get_basic_layout_key(keycode);
+            let mods = (input_bytes & 0x1f00) >> 8;
 
-            let input_modifiers = input_bytes & 0x1f00;
-
-            // A lone shift over a key with a shifted legend just yields that character
-            // (S(KC_1) == "!"), so render it as a plain key. Compare only the low nibble.
-            if (input_modifiers >> 8) & 0x0f == MOD_LSFT {
-                if let Some(shifted) = inner_key.as_ref().and_then(|k| k.shifted.clone()) {
+            // Shift and AltGr (right-Alt bound as the layout's Level-3 shift)
+            // are the only mods that actually change the output character —
+            // resolve that directly and show it flat, no badge, same as a
+            // plain key's shifted legend needs no badge either. Everything
+            // else (Ctrl/Gui/plain Alt, or AltGr on a layout with no Level 3)
+            // never produces text, so fall through to base key + mod badge.
+            const RIGHT: u16 = 0x10; // QMK's "right-hand variant" bit.
+            let text_modifier = if mods & !RIGHT == MOD_LSFT {
+                Some(crate::os_layout::Modifier::Shift)
+            } else if mods == (MOD_LALT | RIGHT) {
+                Some(crate::os_layout::Modifier::AltGr)
+            } else {
+                None
+            };
+            if let Some(m) = text_modifier {
+                if let Some(text) = crate::os_layout::resolve(keycode, m) {
                     return Some(LayoutKey {
-                        tap: Label::new(shifted),
+                        tap: Label::new(text),
                         ..Default::default()
                     });
                 }
             }
 
-            // Otherwise show the key in `tap` and the modifiers as glyphs in the argument
-            // strip (e.g. "C" + "⎈" for LCTL(KC_C)).
-            let (tap, symbol) = match inner_key {
+            let (tap, symbol) = match get_basic_layout_key(keycode) {
                 Some(k) => (k.tap, k.symbol),
                 None => (Label::new(format!("0x{:02X}", keycode)), None),
             };
             Some(LayoutKey {
                 tap,
-                argument: Some(mod_value_to_label(input_modifiers >> 8)),
+                argument: Some(mod_value_to_label(mods)),
                 symbol,
                 kind: KeycodeKind::Modifier,
                 ..Default::default()
@@ -111,4 +119,23 @@ fn mod_value_to_label(mod_mask: u16) -> Label {
         mod_mask & MOD_LALT != 0,
         mod_mask & MOD_LGUI != 0,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_advanced_layout_key;
+
+    // A Shift-wrapped key (LSFT(KC_0) == (MOD_LSFT << 8) | KC_0) shows the
+    // flat resulting character, not a Base+Shifted stack, and no badge —
+    // the modifier's effect IS the output, so there's nothing left to badge.
+    // The expected char is German-specific (AZERTY's digit row shifts
+    // symbols<->digits entirely differently) — needs a live German session.
+    #[test]
+    #[ignore]
+    fn shift_wrapped_key_shows_flat_result_no_badge() {
+        let key = get_advanced_layout_key(0x0227).unwrap();
+        assert_eq!(key.tap.full, "=");
+        assert!(key.shifted.is_none());
+        assert!(key.argument.is_none());
+    }
 }

--- a/src/qmk_keycode_labels/basic.rs
+++ b/src/qmk_keycode_labels/basic.rs
@@ -6,6 +6,59 @@ use qmk_via_api::keycodes::Keycode;
 pub fn get_basic_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
     let keycode = Keycode::try_from(keycode_bytes).ok()?;
 
+    let mut key = get_basic_layout_key_static(keycode)?;
+
+    // A-Z (HID usage 0x04..=0x1D) move between layouts too — QWERTZ swaps
+    // Y and Z with QWERTY, AZERTY reshuffles nearly the whole row — so their
+    // `tap` needs the same OS override, just uppercased and without ever
+    // touching `shifted` (letters intentionally show no separate legend).
+    if (0x04..=0x1D).contains(&keycode_bytes) {
+        if let Some(os_base) = crate::os_layout::base_char(keycode_bytes) {
+            key.tap = Label::new(os_base.to_uppercase());
+        }
+        return Some(key);
+    }
+
+    // Only *replace* a symbol/digit key's legend (the static table set both
+    // `tap` and `shifted` there) — space, Enter, etc. return a real (if
+    // useless) character from the OS query too (control chars for
+    // Enter/Backspace/Delete included), but were deliberately `None` here,
+    // and should stay that way. Without this gate every plain key's `tap`
+    // — e.g. KC_SLASH's US "/" — would otherwise never localize (German's
+    // base char there is "-"), even though `shifted` already did.
+    if key.shifted.is_some() {
+        // QMK's basic keycodes are numerically USB HID usage IDs, so this is
+        // the same call ZMK's HidUsage-based lookup would make. Prefer the
+        // OS's actual active layout over the static (US-only) table above
+        // when it's available (Linux/Wayland only for now — see `os_layout`).
+        let os_base = crate::os_layout::base_char(keycode_bytes);
+        let os_shifted = crate::os_layout::shifted_char(keycode_bytes);
+
+        if let Some(base) = &os_base {
+            // A layout can put a genuine letter on a US-symbol slot (German
+            // semicolon-slot -> "ö") — render it like a letter (uppercase,
+            // no stacked legend) ONLY if Shift does nothing but capitalize
+            // it. AZERTY puts accented letters on the *digit row* instead
+            // ("2" key -> base "é", shifted "2") — there Shift produces a
+            // genuinely different, useful character, so that case must keep
+            // the normal Base+Shifted stack instead of swallowing the digit.
+            let is_mere_capitalization = base.chars().next().is_some_and(char::is_alphabetic)
+                && os_shifted.as_deref().is_none_or(|s| s == base.to_uppercase());
+            if is_mere_capitalization {
+                key.tap = Label::new(base.to_uppercase());
+                key.shifted = None;
+                return Some(key);
+            }
+            key.tap = Label::new(base.clone());
+        }
+        if let Some(shifted) = os_shifted {
+            key.shifted = Some(shifted);
+        }
+    }
+    Some(key)
+}
+
+fn get_basic_layout_key_static(keycode: Keycode) -> Option<LayoutKey> {
     match keycode {
         Keycode::KC_NO => Some(LayoutKey {
             tap: Label::new(""),
@@ -223,6 +276,7 @@ pub fn get_basic_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
         }),
         Keycode::KC_NONUS_HASH => Some(LayoutKey {
             tap: Label::new("NUHS"),
+            shifted: Some("NUHS".to_string()),
             ..Default::default()
         }),
         Keycode::KC_SEMICOLON => Some(LayoutKey {
@@ -440,6 +494,7 @@ pub fn get_basic_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
         }),
         Keycode::KC_NONUS_BACKSLASH => Some(LayoutKey {
             tap: Label::new("NUBS"),
+            shifted: Some("NUBS".to_string()),
             ..Default::default()
         }),
         Keycode::KC_APPLICATION => Some(LayoutKey {
@@ -2911,5 +2966,60 @@ pub fn get_basic_layout_key(keycode_bytes: u16) -> Option<LayoutKey> {
             tap: Label::with_short("User 31", "Usr31"),
             ..Default::default()
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_basic_layout_key;
+    use qmk_via_api::keycodes::Keycode;
+
+    // Regression guard: a plain digit key must always carry its shifted
+    // legend (at minimum the static US-layout fallback), never collapse to
+    // just `tap` with no `shifted` at all.
+    #[test]
+    fn plain_digit_keeps_a_shifted_legend() {
+        let key = get_basic_layout_key(Keycode::KC_8 as u16).unwrap();
+        eprintln!("KC_8 -> tap={:?} shifted={:?}", key.tap.full, key.shifted);
+        assert!(key.shifted.is_some());
+    }
+
+    // Regression guard: `tap` must localize too, not just `shifted` — on a
+    // German layout KC_SLASH's base char is "-", not the US "/". Layout-
+    // dependent (needs a live German Wayland session), like the os_layout
+    // live tests — not part of the normal `cargo test` run.
+    #[test]
+    #[ignore]
+    fn symbol_key_tap_localizes_too() {
+        let key = get_basic_layout_key(Keycode::KC_SLASH as u16).unwrap();
+        eprintln!("KC_SLASH -> tap={:?} shifted={:?}", key.tap.full, key.shifted);
+        assert_eq!(key.tap.full, "-");
+        assert_eq!(key.shifted.as_deref(), Some("_"));
+    }
+
+    // Regression guard: AZERTY puts accented letters on the digit row
+    // ("2" key -> base "é", shifted "2") — Shift there is a genuinely
+    // different, useful character, so it must NOT collapse into a flat
+    // letter display like German ö/Ö does. Needs a live French session.
+    #[test]
+    #[ignore]
+    fn azerty_digit_row_keeps_the_shifted_digit() {
+        let key = get_basic_layout_key(Keycode::KC_2 as u16).unwrap();
+        eprintln!("KC_2 -> tap={:?} shifted={:?}", key.tap.full, key.shifted);
+        assert_eq!(key.tap.full, "é");
+        assert_eq!(key.shifted.as_deref(), Some("2"));
+    }
+
+    // Regression guard: letters must localize too (QWERTZ swaps Y/Z,
+    // AZERTY swaps A/Q) — uppercased, `shifted` stays untouched (None).
+    // Expects a US/German-family layout (AZERTY legitimately gives "Q"
+    // here), so needs a matching live session.
+    #[test]
+    #[ignore]
+    fn letter_key_tap_localizes_and_uppercases() {
+        let key = get_basic_layout_key(Keycode::KC_A as u16).unwrap();
+        eprintln!("KC_A -> tap={:?} shifted={:?}", key.tap.full, key.shifted);
+        assert_eq!(key.tap.full, "A");
+        assert!(key.shifted.is_none());
     }
 }

--- a/src/zmk_keycode_labels/keycode_label.rs
+++ b/src/zmk_keycode_labels/keycode_label.rs
@@ -3,15 +3,63 @@ use crate::layout_key::{KeycodeKind, Label, LayoutKey};
 use zmk_studio_api::Keycode;
 
 pub fn keycode_to_layout_key(keycode: &Keycode) -> LayoutKey {
-    if let Some(key) = keycode_label(keycode) {
-        return key;
-    }
+    let mut key = match keycode_label(keycode) {
+        Some(key) => key,
+        None => LayoutKey {
+            tap: Label::new(keycode.to_name()),
+            ..Default::default()
+        },
+    };
 
-    let name = keycode.to_name();
-    LayoutKey {
-        tap: Label::new(name),
-        ..Default::default()
+    // ZMK's Keycode packs (usage page << 16 | usage id); only the Keyboard
+    // page (0x0007) is meaningful to os_layout (same numeric space QMK's
+    // Keycode already uses there).
+    let raw = *keycode as u32;
+    if raw >> 16 == 0x0007 {
+        let usage = (raw & 0xFFFF) as u16;
+
+        // A-Z move between layouts too (QWERTZ swaps Y/Z, AZERTY reshuffles
+        // most of the row) — uppercase `tap` override, `shifted` untouched
+        // (letters intentionally show no separate legend).
+        if (0x04..=0x1D).contains(&usage) {
+            if let Some(os_base) = crate::os_layout::base_char(usage) {
+                key.tap = Label::new(os_base.to_uppercase());
+            }
+            return key;
+        }
+
+        // Only *replace* a symbol/digit key's legend (the static table set
+        // both `tap` and `shifted` there) — space, Enter/etc. would
+        // otherwise pick up a real but useless character from the OS,
+        // including literal control chars, so they were deliberately left
+        // `None` and should stay that way.
+        if key.shifted.is_some() {
+            let os_base = crate::os_layout::base_char(usage);
+            let os_shifted = crate::os_layout::shifted_char(usage);
+
+            if let Some(base) = &os_base {
+                // A layout can put a genuine letter on a US-symbol slot
+                // (German semicolon-slot -> "ö") — render it like a letter
+                // (uppercase, no stacked legend) ONLY if Shift does nothing
+                // but capitalize it. AZERTY puts accented letters on the
+                // *digit row* instead ("2" key -> base "é", shifted "2") —
+                // there Shift produces a genuinely different, useful
+                // character, so keep the normal Base+Shifted stack there.
+                let is_mere_capitalization = base.chars().next().is_some_and(char::is_alphabetic)
+                    && os_shifted.as_deref().is_none_or(|s| s == base.to_uppercase());
+                if is_mere_capitalization {
+                    key.tap = Label::new(base.to_uppercase());
+                    key.shifted = None;
+                    return key;
+                }
+                key.tap = Label::new(base.clone());
+            }
+            if let Some(shifted) = os_shifted {
+                key.shifted = Some(shifted);
+            }
+        }
     }
+    key
 }
 
 fn keycode_label(keycode: &Keycode) -> Option<LayoutKey> {
@@ -235,7 +283,11 @@ fn keycode_label(keycode: &Keycode) -> Option<LayoutKey> {
             ..Default::default()
         }),
         Keycode::NON_US_HASH => Some(LayoutKey {
-            tap: Label::new("NUHS"),
+            tap: Label::new(
+                crate::os_layout::base_char((Keycode::NON_US_HASH as u32 & 0xFFFF) as u16)
+                    .unwrap_or_else(|| "NUHS".to_string()),
+            ),
+            shifted: crate::os_layout::shifted_char((Keycode::NON_US_HASH as u32 & 0xFFFF) as u16),
             ..Default::default()
         }),
         Keycode::SEMICOLON => Some(LayoutKey {
@@ -906,7 +958,13 @@ fn keycode_label(keycode: &Keycode) -> Option<LayoutKey> {
             ..Default::default()
         }),
         Keycode::NON_US_BACKSLASH => Some(LayoutKey {
-            tap: Label::new("NUBS"),
+            tap: Label::new(
+                crate::os_layout::base_char((Keycode::NON_US_BACKSLASH as u32 & 0xFFFF) as u16)
+                    .unwrap_or_else(|| "NUBS".to_string()),
+            ),
+            shifted: crate::os_layout::shifted_char(
+                (Keycode::NON_US_BACKSLASH as u32 & 0xFFFF) as u16,
+            ),
             ..Default::default()
         }),
         Keycode::C_POWER => Some(LayoutKey {


### PR DESCRIPTION
As discussed in #30 — this replaces the static per-language table approach with reading the compositor's actual active XKB keymap live, so labels match whatever layout is really running.

## What this does

- New `os_layout` module: takes a USB HID Keyboard-page usage ID (the same numeric space both QMK's `Keycode` and ZMK's `HidUsage` already use, so it's protocol-independent by construction) and resolves the character the active layout produces for it, at a given modifier (Base/Shift/AltGr).
- Linux/Wayland backend: binds `wl_seat`/`wl_keyboard` directly and parses the compositor-delivered keymap via `libxkbcommon`. Deliberately never creates a `wl_surface` — this overlay must never be given keyboard focus. Core `wl_keyboard` protocol delivers the active keymap to any bound client regardless of focus, and resends it live if the layout changes at runtime. Other platforms return `None` for now, so callers fall back to the existing static US table unchanged — adding Windows/macOS is a comparable-effort follow-up as a sibling module, no changes needed elsewhere.
- Wired into both QMK (`basic.rs`) and ZMK (`keycode_label.rs`) label resolution:
  - A plain key's `tap` *and* `shifted` both localize now (e.g. `KC_SLASH`'s base is "-" on German, not the static "/").
  - A-Z (and any symbol slot a layout maps to a real letter, e.g. German's semicolon slot -> "ö") render as a single uppercase glyph with no separate legend — unless Shift produces something other than mere capitalization, which AZERTY's digit row does (base "é", shifted "2"), in which case the normal Base+Shifted stack is kept so that useful digit isn't lost.
  - `advanced.rs`: Shift/AltGr-wrapped combos (`LSFT(x)`, `RALT(x)`) resolve through the same mechanism — a text-producing modifier (Shift, or AltGr on a layout that defines a Level 3) shows the flat resulting character with no badge; a non-text modifier (Ctrl/Gui/plain Alt, or AltGr where the layout defines nothing) falls back to the base key + modifier badge.

Verified live against a real Vial keyboard across US, German, French, and Italian active layouts.

## Open question

Whether Shift/AltGr combos should ever show a badge alongside the resolved character, or always resolve flat as done here — happy to adjust based on what you'd prefer.