### PR TITLE
Fix Linux AppImage missing libxdo.so.3 at runtime

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,7 +43,6 @@ jobs:
           cargo appimage
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
-          APPIMAGE_LINUXDEPLOY_EXTRA_ARGS: "--library /usr/lib/x86_64-linux-gnu/libxdo.so.3"
 
       - name: Get version
         id: get_version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,32 @@ winresource = "0.1.31"
 name = "KeyPeek"
 identifier = "dev.srwi.keypeek"
 osx_info_plist_exts = ["resources/macos-info-plist-ext.xml"]
+
+[package.metadata.appimage]
+# Bundle only libxdo: it's the one dependency that is NOT part of every
+# mainstream distro's base desktop stack (Ubuntu/Fedora/Arch etc. all ship
+# GTK/X11/Wayland/Mesa already, but libxdo comes from the niche `xdotool`
+# project and is often missing or has a different soname). Everything else
+# stays excluded so we don't ship a second copy of GTK/Mesa/X11 that could
+# clash with the host's graphics drivers and theme integration.
+auto_link = true
+auto_link_exclude_list = [
+    "ld-linux*", "libc.so*", "libm.so*", "libdl.so*", "libpthread.so*", "librt.so*",
+    "libgcc_s.so*", "libstdc++.so*",
+    "libgtk-3.so*", "libgdk-3.so*", "libgdk_pixbuf-2.0.so*", "libgio-2.0.so*",
+    "libgobject-2.0.so*", "libglib-2.0.so*", "libgmodule-2.0.so*",
+    "libX11.so*", "libXi.so*", "libXext.so*", "libXfixes.so*", "libXcursor.so*",
+    "libXdamage.so*", "libXcomposite.so*", "libXrandr.so*", "libXinerama.so*",
+    "libXrender.so*", "libXau.so*", "libXdmcp.so*", "libxcb*.so*",
+    "libwayland-*.so*", "libEGL.so*", "libGLdispatch.so*", "libepoxy.so*",
+    "libxkbcommon.so*",
+    "libpango*.so*", "libcairo*.so*", "libharfbuzz.so*", "libfribidi.so*",
+    "libfontconfig.so*", "libfreetype.so*", "libthai.so*", "libdatrie.so*",
+    "libgraphite2.so*", "libpixman-1.so*", "libpng16.so*",
+    "libatk*.so*", "libatspi.so*", "libcloudproviders.so*", "libtinysparql*.so*",
+    "libglycin*.so*",
+    "libudev.so*", "libsystemd.so*", "libdbus-1.so*", "libmount.so*", "libblkid.so*",
+    "libffi.so*", "libpcre2*.so*", "libz.so*", "libbz2.so*", "libbrotli*.so*",
+    "libseccomp.so*", "libexpat.so*", "libjson-glib*.so*", "libxml2.so*",
+    "libsqlite3.so*", "liblcms2.so*", "libicu*.so*",
+]


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/srwi/keypeek/blob/master/CONTRIBUTING.md)

## Summary

As already mentioned in Issue #42 Enable auto_link and exclude everything already provided by mainstream desktop stacks (GTK/X11/Wayland/Mesa/glibc/...), so only libxdo (and its libXtst dependency) actually get bundled. 
Drop the now-dead APPIMAGE_LINUXDEPLOY_EXTRA_ARGS line from the workflow.

Verified locally with cargo-appimage 2.4.0 + appimagetool: the built AppDir's usr/lib contains exactly libxdo.so.4 and libXtst.so.6, ldd resolves cleanly against the bundled libs, and the resulting AppImage launches successfully (previously failed with
"libxdo.so.3: cannot open shared object file").

## Related issue

Fixes #42

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] UI change
- [ ] Documentation update
- [ ] Refactoring / maintenance


